### PR TITLE
Improve compatibility with headless themes

### DIFF
--- a/Vipps.class.php
+++ b/Vipps.class.php
@@ -3063,7 +3063,7 @@ EOF;
         } else {
             $url = "/$what/";
         }
-        return untrailingslashit(set_url_scheme(home_url(),'https')) . $url;
+        return untrailingslashit(home_url($url, 'https'));
     }
     public function payment_return_url() {
         return apply_filters('woo_vipps_payment_return_url', $this->make_return_url('vipps-betaling')); 

--- a/VippsApi.class.php
+++ b/VippsApi.class.php
@@ -213,6 +213,8 @@ class VippsApi {
 
         $this->log("Initiating Vipps session for $vippsorderid", 'debug');
 
+        $data = apply_filters('woo_vipps_initiate_payment_data', $data);
+
         $res = $this->http_call($command,$data,'POST',$headers,'json'); 
         return $res;
     }
@@ -328,6 +330,8 @@ class VippsApi {
          // Enum: "CUSTOMER_PRESENT" "CUSTOMER_NOT_PRESENT"
          $data['customerInteraction'] = "";
         }
+
+        $data = apply_filters('woo_vipps_initiate_checkout_data', $data);
 
         $res = $this->http_call($command,$data,'POST',$headers,'json'); 
 

--- a/WC_Gateway_Vipps.class.php
+++ b/WC_Gateway_Vipps.class.php
@@ -213,9 +213,9 @@ class WC_Gateway_Vipps extends WC_Payment_Gateway {
         // HTTPS required. IOK 2018-05-18
         // If the user for some reason hasn't enabled pretty links, fall back to ancient version. IOK 2018-04-24
         if ( !get_option('permalink_structure')) {
-            return untrailingslashit(set_url_scheme(home_url(),'https')) . "/?wc-api=$forwhat&$tk&callback=";
+            return untrailingslashit(home_url("/?wc-api=$forwhat&$tk&callback=", 'https'));
         } else {
-            return untrailingslashit(set_url_scheme(home_url(),'https')) . "/wc-api/$forwhat?$tk&callback=";
+            return untrailingslashit(home_url("/wc-api/$forwhat?$tk&callback=", 'https'));
         }
     }
     // The main payment callback
@@ -229,9 +229,9 @@ class WC_Gateway_Vipps extends WC_Payment_Gateway {
     // IOK 2018-05-18
     public function consent_removal_callback_url () {
         if ( !get_option('permalink_structure')) {
-            return untrailingslashit(set_url_scheme(home_url(),'https')) . "/?vipps-consent-removal&callback=";
+            return untrailingslashit(home_url("/?vipps-consent-removal&callback=", 'https'));
         } else {
-            return untrailingslashit(set_url_scheme(home_url(),'https')) . "/vipps-consent-removal/?callback=";
+            return untrailingslashit(home_url("/vipps-consent-removal/?callback=", 'https'));
         }
     }
 


### PR DESCRIPTION
Changed:
- Use the `$path` and `$scheme` arguments to the `home_url()` function
  instead of concatenating URLs.  This allows headless themes to filter
  the server-to-server URLs and frontend URLs properly.

Added:
- New filters for the data sent in `initiate_payment` and
  `initiate_checkout`, which allows for more control over the return URL
  which is especially important for headless themes.