### PR TITLE
Handle when host is empty with siteurl = localhost

### DIFF
--- a/Vipps.class.php
+++ b/Vipps.class.php
@@ -723,7 +723,7 @@ class Vipps {
     public function generate_order_prefix() {
         $parts = parse_url(site_url());
         if (!$parts) return 'Woo';
-        $domain = explode(".", $parts['host']);
+        $domain = explode(".", $parts['host'] ?? '');
         if (empty($domain)) return 'Woo';
         $first = strtolower($domain[0]);
         $second = isset($domain[1]) ? $domain[1] : ''; 


### PR DESCRIPTION
# Issue
I found this issue when I run plugin in local environment, with siteurl = `localhost`
it will happens when session of admin was expired and they try to access to WP Backend again

# What happen
when admin user open with Backend URL after login session was expired
it will throw warning error
```
Warning: Undefined array key "host" in /var/www/app/wp-content/plugins/woo-vipps/Vipps.class.php on line 726
``` 
in my local environment, I used xdebug for debugging.

# How to solve
in file Vipps.class.php, I added `??` operator when key host not found or null