### PR TITLE
Recurring/2.1.4

### DIFF
--- a/recurring/changelog.txt
+++ b/recurring/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 2.1.4 =
+* Fixed: Actually fixed abandoned Checkout orders not being deleted this time.
+
 = 2.1.3 =
 * Fixed: We were still using calls to `get_posts` a few places, which was incompatible with WooCommerce HPOS. This fixes gateway changes, in-app description updates, and in-app subscription cancellation for installations using HPOS.
 * Fixed: Some payments that were cancelled quickly could get stuck in a "MobilePay payments are automatically captured" loop for merchants using MobilePay.

--- a/recurring/changelog.txt
+++ b/recurring/changelog.txt
@@ -2,6 +2,7 @@
 
 = 2.1.4 =
 * Fixed: Actually fixed abandoned Checkout orders not being deleted this time.
+* Fixed: Payments towards a failed renewal order are now possible.
 
 = 2.1.3 =
 * Fixed: We were still using calls to `get_posts` a few places, which was incompatible with WooCommerce HPOS. This fixes gateway changes, in-app description updates, and in-app subscription cancellation for installations using HPOS.

--- a/recurring/changelog.txt
+++ b/recurring/changelog.txt
@@ -3,6 +3,7 @@
 = 2.1.4 =
 * Fixed: Actually fixed abandoned Checkout orders not being deleted this time.
 * Fixed: Payments towards a failed renewal order are now possible.
+* Fixed: When using Checkout it will no longer tell you that you already have a subscription when you haven't paid yet.
 
 = 2.1.3 =
 * Fixed: We were still using calls to `get_posts` a few places, which was incompatible with WooCommerce HPOS. This fixes gateway changes, in-app description updates, and in-app subscription cancellation for installations using HPOS.

--- a/recurring/includes/admin/list-tables/wc-vipps-recurring-list-table-failed-charges.php
+++ b/recurring/includes/admin/list-tables/wc-vipps-recurring-list-table-failed-charges.php
@@ -60,9 +60,13 @@ class WC_Vipps_Recurring_Admin_List_Failed_Charges extends WP_List_Table {
 			'offset'         => ( $paged - 1 ) * $orders_per_page,
 			'search'         => $ordersearch,
 			'paginate'       => true,
-			'meta_key'       => WC_Vipps_Recurring_Helper::META_CHARGE_FAILED,
-			'meta_value'     => 1,
-			'type'           => 'shop_order',
+			'meta_query'     => [
+				[
+					'key'     => WC_Vipps_Recurring_Helper::META_CHARGE_FAILED,
+					'compare' => '=',
+					'value'   => 1
+				]
+			],
 			'payment_method' => 'vipps_recurring'
 		];
 
@@ -177,8 +181,8 @@ class WC_Vipps_Recurring_Admin_List_Failed_Charges extends WP_List_Table {
 	 */
 	protected function get_sortable_columns() {
 		return [
-			'order'          => [ 'order', true ],
-			'created_at'     => [ 'created_at', true ]
+			'order'      => [ 'order', true ],
+			'created_at' => [ 'created_at', true ]
 		];
 	}
 

--- a/recurring/includes/admin/list-tables/wc-vipps-recurring-list-table-pending-charges.php
+++ b/recurring/includes/admin/list-tables/wc-vipps-recurring-list-table-pending-charges.php
@@ -60,10 +60,13 @@ class WC_Vipps_Recurring_Admin_List_Pending_Charges extends WP_List_Table {
 			'offset'         => ( $paged - 1 ) * $orders_per_page,
 			'search'         => $ordersearch,
 			'paginate'       => true,
-			'type'           => 'shop_order',
-			'meta_key'       => WC_Vipps_Recurring_Helper::META_CHARGE_PENDING,
-			'meta_compare'   => '=',
-			'meta_value'     => 1,
+			'meta_query'     => [
+				[
+					'key'     => WC_Vipps_Recurring_Helper::META_CHARGE_PENDING,
+					'compare' => '=',
+					'value'   => 1
+				]
+			],
 			'payment_method' => 'vipps_recurring'
 		];
 

--- a/recurring/includes/wc-gateway-vipps-recurring.php
+++ b/recurring/includes/wc-gateway-vipps-recurring.php
@@ -11,1780 +11,1780 @@ require_once( __DIR__ . '/wc-vipps-recurring-api.php' );
  * @extends WC_Payment_Gateway
  */
 class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
-	/**
-	 * Which brand to use, will be one of: vipps, mobilepay
-	 */
-	public string $brand;
-
-	/**
-	 * Vipps MobilePay merchant serial number
-	 */
-	public string $merchant_serial_number;
-
-	/**
-	 * Whether Vipps MobilePay Checkout is enabled
-	 */
-	public bool $checkout_enabled;
-
-	public string $order_prefix;
-
-	/**
-	 * Is test mode active?
-	 */
-	public bool $test_mode;
-
-	/**
-	 * The default status to give pending renewals
-	 */
-	public string $default_renewal_status;
-
-	/**
-	 * The default status pending orders that have yet to be captured (reserved charges in Vipps/MobilePay) should be given
-	 */
-	public string $default_reserved_charge_status;
-
-	/**
-	 * Status where when transitioned to we will attempt to capture the payment
-	 */
-	public array $statuses_to_attempt_capture;
-
-	/**
-	 * Transition the order status to 'completed' when a renewal order has been charged successfully
-	 * regardless of previous status
-	 */
-	public bool $transition_renewals_to_completed;
-
-	/**
-	 * The amount of charges to check in wp-cron at a time
-	 */
-	public int $check_charges_amount;
-
-	/**
-	 * The sort order in which we check charges in wp-cron
-	 */
-	public string $check_charges_sort_order;
-
-	/**
-	 * The reference the *Singleton* instance of this class
-	 */
-	private static ?WC_Gateway_Vipps_Recurring $instance = null;
-
-	public WC_Vipps_Recurring_Api $api;
-
-	public ?bool $use_high_performance_order_storage = null;
-
-	public bool $auto_capture_mobilepay = false;
-
-	public ?string $continue_shopping_link_page = null;
-
-	/**
-	 * Returns the *Singleton* instance of this class.
-	 *
-	 * @return WC_Gateway_Vipps_Recurring The *Singleton* instance.
-	 */
-	public static function get_instance(): WC_Gateway_Vipps_Recurring {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
-	}
-
-	/**
-	 * Constructor
-	 */
-	public function __construct() {
-		$this->id                 = 'vipps_recurring';
-		$this->method_title       = __( 'Vipps/MobilePay Recurring Payments', 'woo-vipps' );
-		$this->method_description = __( 'Vipps/MobilePay Recurring Payments works by redirecting your customers to the Vipps MobilePay portal for confirmation. It creates a payment plan and charges your users on the intervals you specify.', 'woo-vipps' );
-		$this->has_fields         = true;
-
-		/*
-		 * Do not add 'multiple_subscriptions' to $supports.
-		 * Vipps/MobilePay Recurring API does not have any concept of multiple line items at the time of writing this.
-		 * It could technically be possible to support this, but it's very confusing for a customer in the Vipps/MobilePay app.
-		 * There are a lot of edge cases to think about in order to support this functionality too,
-		 * 'process_payment' would have to be rewritten entirely.
-		 */
-		$this->supports = [
-			'products',
-			'subscriptions',
-			'refunds',
-			'subscription_cancellation',
-			'subscription_suspension',
-			'subscription_reactivation',
-			'subscription_amount_changes',
-			'subscription_date_changes',
-			'subscription_payment_method_change',
-			'subscription_payment_method_change_customer',
-			'subscription_payment_method_change_admin',
-		];
-
-		// Load the form fields.
-		$this->init_form_fields();
-
-		// Load the settings.
-		$this->init_settings();
-
-		$this->brand                            = $this->get_option( 'brand' );
-		$this->title                            = $this->get_form_fields()['brand']['options'][ $this->brand ];
-		$this->description                      = str_replace( '{brand}', $this->title, $this->get_option( 'description' ) );
-		$this->enabled                          = $this->get_option( 'enabled' );
-		$this->test_mode                        = $this->get_option( 'test_mode' ) === "yes";
-		$this->merchant_serial_number           = $this->get_option( 'merchant_serial_number' );
-		$this->checkout_enabled                 = $this->get_option( 'checkout_enabled' ) === "yes";
-		$this->order_prefix                     = $this->get_option( 'order_prefix' );
-		$this->default_renewal_status           = $this->get_option( 'default_renewal_status' );
-		$this->default_reserved_charge_status   = $this->get_option( 'default_reserved_charge_status' );
-		$this->transition_renewals_to_completed = $this->get_option( 'transition_renewals_to_completed' ) === "yes";
-		$this->check_charges_amount             = $this->get_option( 'check_charges_amount' );
-		$this->check_charges_sort_order         = $this->get_option( 'check_charges_sort_order' );
-		$this->auto_capture_mobilepay           = $this->get_option( 'auto_capture_mobilepay' ) === "yes";
-		$this->continue_shopping_link_page      = $this->get_option( 'continue_shopping_link_page' );
-
-		if ( WC_VIPPS_RECURRING_TEST_MODE ) {
-			$this->test_mode = true;
-		}
-
-		if ( $this->test_mode ) {
-			$this->merchant_serial_number = $this->get_option( 'test_merchant_serial_number' );
-		}
-
-		// translators: %s: brand name, Vipps or MobilePay
-		$this->order_button_text = sprintf( __( 'Pay with %s', 'woo-vipps' ), $this->title );
-
-		$this->api = new WC_Vipps_Recurring_Api( $this );
-
-		/*
-		 * When transitioning an order to these statuses we should
-		 * automatically try to capture the charge if it's not already captured
-		 */
-		$capture_statuses = [
-			'completed',
-			'processing'
-		];
-
-		/*
-		 * We have to remove the status corresponding to `$this->default_reserved_charge_status` otherwise we end up
-		 * prematurely capturing this reserved Vipps/MobilePay charge
-		 */
-		$capture_status_transition_id = array_search( str_replace( 'wc-', '', $this->default_reserved_charge_status ), $capture_statuses, true );
-		if ( $capture_status_transition_id ) {
-			unset( $capture_statuses[ $capture_status_transition_id ] );
-		}
-
-		$this->statuses_to_attempt_capture = apply_filters( 'wc_vipps_recurring_captured_statuses', $capture_statuses );
-
-		// If we change a status that is currently on-hold to any of the $capture_statuses we should attempt to capture it
-		foreach ( $this->statuses_to_attempt_capture as $status ) {
-			add_action( 'woocommerce_order_status_' . $status, [ $this, 'maybe_capture_payment' ] );
-		}
-
-		add_filter( 'woocommerce_valid_order_statuses_for_payment_complete', [
-			$this,
-			'append_valid_statuses_for_payment_complete'
-		] );
-
-		add_action( 'woocommerce_order_status_pending_to_cancelled', [ $this, 'maybe_delete_order' ], 99999 );
-		add_action( 'woocommerce_new_order', [ $this, 'maybe_delete_order_later' ] );
-		add_action( 'woocommerce_vipps_recurring_delete_pending_order', [ $this, 'maybe_delete_order' ] );
-
-		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [
-			$this,
-			'process_admin_options'
-		] );
-
-		add_action( 'woocommerce_account_view-order_endpoint', [ $this, 'check_charge_status' ], 1 );
-
-		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
-
-		add_action( 'woocommerce_scheduled_subscription_payment_' . $this->id, [
-			$this,
-			'scheduled_subscription_payment'
-		], 1, 2 );
-
-		add_action( 'woocommerce_subscription_cancelled_' . $this->id, [
-			$this,
-			'cancel_subscription',
-		] );
-
-		add_action( 'woocommerce_before_thankyou', [ $this, 'maybe_process_redirect_order' ], 1 );
-
-		add_action( 'woocommerce_subscription_failing_payment_method_updated_' . $this->id, [
-			$this,
-			'update_failing_payment_method'
-		], 10, 2 );
-
-		/*
-		 * When changing the payment method for a WooCommerce Subscription to Vipps MobilePay, let WooCommerce Subscription
-		 * know that the payment method for that subscription should not be changed immediately. Instead, it should
-		 * wait for the go ahead in cron, after the user confirmed the payment method change with Vipps MobilePay.
-		 */
-		add_filter( 'woocommerce_subscriptions_update_payment_via_pay_shortcode', [
-			$this,
-			'indicate_async_payment_method_update'
-		], 10, 2 );
-
-		// Tell WooCommerce about our custom payment meta fields
-		add_action( 'woocommerce_subscription_payment_meta', [ $this, 'add_subscription_payment_meta' ], 10, 2 );
-
-		// Validate custom payment meta fields
-		add_action( 'woocommerce_subscription_validate_payment_meta', [
-			$this,
-			'validate_subscription_payment_meta'
-		], 10, 2 );
-
-		// Handle subscription switches (free upgrades & downgrades)
-		add_action( 'woocommerce_subscriptions_switched_item', [ $this, 'handle_subscription_switch_completed' ] );
-
-		// If we are performing a subscription switch to Vipps Recurring we need to take a payment
-		// todo: Figure out how to force a redirect to Vipps here. We do need to sign a new agreement in a lot of cases...
-		// todo: Vipps has a 10x multiplier limit for the agreement pricing.
-		add_filter( 'woocommerce_cart_needs_payment', [ $this, 'cart_needs_payment' ], 100, 2 );
-
-		/*
-		 * Handle in app updates when a subscription status changes, typically when status transitions to
-		 * 'pending-cancel', 'cancelled' or 'pending-cancel' to any other status
-		 */
-		add_action( 'woocommerce_subscription_status_updated', [
-			$this,
-			'maybe_handle_subscription_status_transitions'
-		], 10, 3 );
-
-		// Delete idempotency key when renewal/resubscribe happens
-		add_action( 'wcs_resubscribe_order_created', [ $this, 'delete_resubscribe_meta' ] );
-		add_action( 'wcs_renewal_order_created', [ $this, 'delete_renewal_meta' ] );
-
-		// Cancel DUE charge if order transitions to 'cancelled' or 'failed'
-		$cancel_due_charge_statuses = apply_filters( 'wc_vipps_recurring_cancel_due_charge_statuses', [
-			'cancelled',
-			'failed'
-		] );
-
-		foreach ( $cancel_due_charge_statuses as $status ) {
-			add_action( 'woocommerce_order_status_' . $status, [ $this, 'maybe_cancel_due_charge' ] );
-		}
-
-		add_action( 'woocommerce_payment_complete', [ $this, 'after_renew_early_from_another_gateway' ] );
-
-		add_filter( 'woocommerce_payment_complete_order_status', [
-			$this,
-			'prevent_backwards_transition_on_completed_order'
-		], 100, 3 );
-
-		add_action( 'woocommerce_order_after_calculate_totals', [ $this, 'update_agreement_price_in_app' ], 10, 2 );
-
-		// Woo Subscriptions uses `wp_safe_redirect()` during a gateway change, which will not allow us to redirect to the Vipps MobilePay API
-		// Unless we whitelist the domains specifically
-		// https://developer.vippsmobilepay.com/docs/knowledge-base/servers/
-		add_filter( 'allowed_redirect_hosts', function ( $hosts ) {
-			return array_merge( $hosts, [
-				// Production servers
-				'api.vipps.no',
-				'api.mobilepay.dk',
-				'api.mobilepay.fi',
-				'pay.vipps.no',
-				'pay.mobilepay.dk',
-				'pay.mobilepay.fi',
-				// MT servers
-				'apitest.vipps.no',
-				'pay-mt.vipps.no',
-				'pay-mt.mobilepay.dk',
-				'pay-mt.mobilepay.fi'
-			] );
-		} );
-	}
-
-	/**
-	 * Indicate to WooCommerce Subscriptions that the payment method change for Vipps/MobilePay Recurring Payments
-	 * should be asynchronous.
-	 *
-	 * WC_Subscriptions_Change_Payment_Gateway::change_payment_method_via_pay_shortcode uses the
-	 * result to decide whether to change the payment method information on the subscription
-	 * right away or not.
-	 *
-	 * In our case, the payment method will not be updated until after the user confirms the
-	 * payment method change with Vipps MobilePay. Once that's done, we'll take care of finishing
-	 * the payment method update with the subscription.
-	 *
-	 * @param bool $should_update Current value of whether the payment method should be updated immediately.
-	 * @param string $new_payment_method The new payment method name.
-	 *
-	 * @return bool Whether the subscription's payment method should be updated on checkout or async when a response is returned.
-	 */
-	public function indicate_async_payment_method_update( bool $should_update, string $new_payment_method ): bool {
-		if ( $this->id === $new_payment_method ) {
-			$should_update = false;
-		}
-
-		return $should_update;
-	}
-
-	/**
-	 * @param $subscription
-	 * @param $renewal_order
-	 */
-	public function update_failing_payment_method( $subscription, $renewal_order ): void {
-		WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $renewal_order ) );
-	}
-
-	/**
-	 * @param $order_id
-	 *
-	 * @throws WC_Vipps_Recurring_Exception
-	 */
-	public function process_redirect_payment( $order_id ): void {
-		$order = wc_get_order( $order_id );
-		if ( ! is_object( $order ) ) {
-			return;
-		}
-
-		$payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $order );
-		if ( $payment_method !== $this->id ) {
-			// If this is not the payment method, an agreement would not be available.
-			return;
-		}
-
-		// check latest charge status
-		$status = $this->check_charge_status( $order_id );
-
-		WC_Vipps_Recurring_Logger::log( sprintf( "[%s] process_redirect_payment: charge status is: %s", $order_id, $status ) );
-	}
-
-	/**
-	 * @param $order_id
-	 *
-	 * @throws WC_Vipps_Recurring_Exception
-	 */
-	public function maybe_process_redirect_order( $order_id ): void {
-		if ( ! is_order_received_page() ) {
-			return;
-		}
-
-		$order = wc_get_order( $order_id );
-		if ( $order->get_payment_method() !== $this->id ) {
-			return;
-		}
-
-		$this->process_redirect_payment( $order_id );
-	}
-
-	/**
-	 * Check if we are using the new HPOS feature from WooCommerce
-	 * This function is used for backwards compatibility in certain places
-	 */
-	public function use_high_performance_order_storage(): bool {
-		if ( $this->use_high_performance_order_storage === null ) {
-			$this->use_high_performance_order_storage = function_exists( 'wc_get_container' ) &&  // 4.4.0
-			                                            function_exists( 'wc_get_page_screen_id' ) && // Exists in the HPOS update
-			                                            class_exists( "Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController" ) &&
-			                                            wc_get_container()->get( Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
-		}
-
-		return $this->use_high_performance_order_storage;
-	}
-
-	/**
-	 * Retrieves the latest charge for an order if any. False if none or invalid agreement id
-	 *
-	 * @param $order
-	 *
-	 * @return bool|WC_Vipps_Charge
-	 * @throws WC_Vipps_Recurring_Exception
-	 */
-	public function get_latest_charge_from_order( $order ) {
-		$agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
-
-		if ( ! $agreement_id ) {
-			return false;
-		}
-
-		$charge_id = WC_Vipps_Recurring_Helper::get_charge_id_from_order( $order );
-		$charge    = false;
-
-		if ( $charge_id ) {
-			try {
-				$charge = $this->api->get_charge( $agreement_id, $charge_id );
-			} catch ( WC_Vipps_Recurring_Temporary_Exception $e ) {
-				// do nothing, we're just being too quick
-			} catch ( Exception $e ) {
-				$charge = $this->get_latest_charge_for_agreement( $order, $agreement_id, $charge_id );
-			}
-		} else {
-			$charge = $this->get_latest_charge_for_agreement( $order, $agreement_id, $charge_id );
-		}
-
-		return $charge;
-	}
-
-	/**
-	 * @param object|WC_Order $order
-	 * @param string $agreement_id
-	 * @param string $charge_id
-	 *
-	 * @return false|null|WC_Vipps_Charge
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 */
-	public function get_latest_charge_for_agreement( $order, string $agreement_id, string $charge_id ) {
-		WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Failed checking charge directly for charge: %s and agreement: %s. This might mean we have not set the right charge id somewhere. Finding latest charge instead.', WC_Vipps_Recurring_Helper::get_id( $order ), $charge_id, $agreement_id ) );
-
-		$charges = $this->api->get_charges_for( $agreement_id );
-
-		// return false if there is no charge
-		// this will tell us if this was directly captured or not
-		if ( count( $charges ) === 0 ) {
-			return false;
-		}
-
-		$charge = null;
-		if ( $charges ) {
-			$charge = array_reverse( $charges )[0];
-		}
-
-		return $charge;
-	}
-
-	/**
-	 * Receives the agreement associated with an order
-	 *
-	 * @param object|WC_Order $order
-	 *
-	 * @return bool|WC_Vipps_Agreement
-	 * @throws WC_Vipps_Recurring_Exception
-	 */
-	public function get_agreement_from_order( $order ) {
-		$agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
-
-		if ( ! $agreement_id ) {
-			return false;
-		}
-
-		return $this->api->get_agreement( $agreement_id );
-	}
-
-	/**
-	 * @param object|WC_Order $order
-	 */
-	public function unlock_order( $order ): void {
-		WC_Vipps_Recurring_Helper::update_meta_data( $order, '_vipps_recurring_locked_for_update_time', 0 );
-		$order->save();
-	}
-
-	/**
-	 * @param $order_id
-	 * @param bool $skip_lock
-	 *
-	 * @return string
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 */
-	public function check_charge_status( $order_id, $skip_lock = false ): string {
-		if ( empty( $order_id ) || absint( $order_id ) <= 0 ) {
-			return 'INVALID';
-		}
-
-		$order = wc_get_order( absint( $order_id ) );
-
-		$payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $order );
-		if ( $payment_method !== $this->id ) {
-			// if this is not the payment method, an agreement would not be available.
-			return 'INVALID';
-		}
-
-		// we need to tell WooCommerce that this is in fact a scheduled payment that should be retried in the case of failure.
-		if ( wcs_order_contains_renewal( $order ) ) {
-			add_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
-		}
-
-		// check if order is temporarily locked
-		if ( ! $this->use_high_performance_order_storage() ) {
-			clean_post_cache( WC_Vipps_Recurring_Helper::get_id( $order ) );
-		}
-
-		// hold on to the lock for 30 seconds
-		$lock = (int) WC_Vipps_Recurring_Helper::get_meta( $order, '_vipps_recurring_locked_for_update_time' );
-		if ( ( $lock && $lock > time() - 30 ) && ! $skip_lock ) {
-			return 'SUCCESS';
-		}
-
-		// lock the order
-		WC_Vipps_Recurring_Helper::update_meta_data( $order, '_vipps_recurring_locked_for_update_time', time() );
-		$order->save();
-
-		$agreement = $this->get_agreement_from_order( $order );
-		if ( ! $agreement ) {
-			// If there is no agreement we can't complete Checkout orders. Let Checkout deal with this through an action.
-			$order_initial = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL );
-
-			if ( $order_initial && $order->get_payment_method() === $this->id ) {
-				do_action( 'wc_vipps_recurring_check_charge_status_no_agreement', $order );
-			}
-
-			return 'INVALID';
-		}
-
-		$is_renewal = wcs_order_contains_renewal( $order );
-
-		// logic for zero amounts when a charge does not exist
-		if ( WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_ZERO_AMOUNT ) && ! $is_renewal ) {
-			// if there's a campaign with a price of 0 we can complete the order immediately
-			if ( $agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE ) {
-				$this->complete_order( $order, $agreement->id );
-
-				$order->add_order_note( __( 'The subtotal is zero, the order is free for this subscription period.', 'woo-vipps' ) );
-				$order->save();
-			}
-
-			// if EXPIRED or STOPPED we can fail this order
-			if ( in_array( $agreement->status, [
-				WC_Vipps_Agreement::STATUS_EXPIRED,
-				WC_Vipps_Agreement::STATUS_STOPPED
-			], true ) ) {
-				$this->check_charge_agreement_cancelled( $order, $agreement );
-
-				return 'CANCELLED';
-			}
-
-			return 'SUCCESS';
-		}
-
-		$charge = $this->get_latest_charge_from_order( $order );
-
-		if ( ! $charge ) {
-			// we're being rate limited
-			return 'SUCCESS';
-		}
-
-		// set _charge_id on order
-		WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $charge->id );
-
-		// set _vipps_recurring_latest_api_status
-		WC_Vipps_Recurring_Helper::set_latest_api_status_for_order( $order, $charge->status );
-
-		$initial        = empty( WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL ) )
-		                  && ! wcs_order_contains_renewal( $order );
-		$pending_charge = $initial ? 1 : (int) WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING );
-		$did_fail       = WC_Vipps_Recurring_Helper::is_charge_failed_for_order( $order );
-
-		// If payment has already been captured, this function is redundant, unless the charge failed
-		if ( ! $pending_charge && ! $did_fail ) {
-			$this->unlock_order( $order );
-
-			return 'SUCCESS';
-		}
-
-		$is_captured = ! in_array( $charge->status, [
-				WC_Vipps_Charge::STATUS_PENDING,
-				WC_Vipps_Charge::STATUS_RESERVED
-			], true ) && $agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE;
-
-		// If the brand is MobilePay, we should capture the payment now if it is not already captured.
-		// This is because MobilePay auto-releases and refunds payments after 7 days. Vipps will keep a reservation for a lot longer.
-		if ( $this->brand === WC_Vipps_Recurring_Helper::BRAND_MOBILEPAY
-		     && ! $is_captured
-		     && $this->auto_capture_mobilepay ) {
-			$order->save();
-
-			if ( $this->maybe_capture_payment( $order_id ) ) {
-				$order->add_order_note( __( 'MobilePay payments are automatically captured to prevent the payment reservation from automatically getting cancelled after 14 days.', 'woo-vipps' ) );
-
-				return 'SUCCESS';
-			}
-		}
-
-		$is_direct_capture = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_DIRECT_CAPTURE );
-		if ( $is_direct_capture && ! $is_captured ) {
-			$order->save();
-
-			$this->maybe_capture_payment( $order_id );
-
-			return 'SUCCESS';
-		}
-
-		WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_CAPTURED, $is_captured );
-
-		if ( (int) $initial ) {
-			WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL, true );
-			WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, true );
-		}
-
-		$this->unlock_order( $order );
-
-		$order->save();
-
-		if ( ! $this->use_high_performance_order_storage() ) {
-			clean_post_cache( WC_Vipps_Recurring_Helper::get_id( $order ) );
-		}
-
-		$this->process_order_charge( $order, $charge );
-
-		// agreement is expired or stopped
-		if ( in_array( $agreement->status, [
-			WC_Vipps_Agreement::STATUS_STOPPED,
-			WC_Vipps_Agreement::STATUS_EXPIRED
-		], true ) ) {
-			$this->check_charge_agreement_cancelled( $order, $agreement, $charge );
-
-			return 'CANCELLED';
-		}
-
-		return 'SUCCESS';
-	}
-
-	/**
-	 * @param $order
-	 * @param WC_Vipps_Agreement $agreement
-	 * @param bool|WC_Vipps_Charge $charge
-	 *
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 */
-	public function check_charge_agreement_cancelled( $order, WC_Vipps_Agreement $agreement, $charge = false ): void {
-		$order->update_status( 'cancelled', __( 'The agreement was cancelled or expired in Vipps/MobilePay', 'woo-vipps' ) );
-
-		WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, false );
-		$order->save();
-
-		// cancel charge
-		if ( $charge && in_array( $charge->status, [
-				WC_Vipps_Charge::STATUS_DUE,
-				WC_Vipps_Charge::STATUS_PENDING
-			], true ) ) {
-			$idempotency_key = $this->get_idempotency_key( $order );
-
-			$this->api->cancel_charge( $agreement->id, $charge->id, $idempotency_key );
-		}
-	}
-
-	/**
-	 * @param $order
-	 * @param $transaction_id
-	 */
-	public function complete_order( $order, $transaction_id ): void {
-		$order->payment_complete( $transaction_id );
-
-		// Controlled by the `transition_renewals_to_completed` setting
-		// Only applicable to renewal orders
-		if ( $this->transition_renewals_to_completed && wcs_order_contains_renewal( $order ) && $order->get_status() !== 'completed' ) {
-			$order->update_status( 'completed' );
-		}
-
-		// Unlock the order and make sure we tell our cronjob to stop periodically checking the status of this order
-		WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, false );
-		$this->unlock_order( $order );
-
-		if ( is_callable( [ $order, 'save' ] ) ) {
-			$order->save();
-		}
-
-		do_action( 'wc_vipps_recurring_after_payment_complete', $order );
-	}
-
-	/**
-	 * @param $order
-	 * @param WC_Vipps_Charge|null $charge
-	 */
-	public function process_order_charge( $order, ?WC_Vipps_Charge $charge = null ): void {
-		if ( ! $charge ) {
-			// No charge
-			return;
-		}
-
-		// If payment has already been completed, this function is redundant.
-		if ( ! WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING ) ) {
-			return;
-		}
-
-		do_action( 'wc_vipps_recurring_before_process_order_charge', $order );
-
-		WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $charge->id );
-		$transaction_id = WC_Vipps_Recurring_Helper::get_transaction_id_for_order( $order );
-
-		// Reduce stock
-		$reduce_stock = $charge->status === WC_Vipps_Charge::STATUS_CHARGED || in_array( $charge->status, [
-				WC_Vipps_Charge::STATUS_DUE,
-				WC_Vipps_Charge::STATUS_PENDING
-			], true );
-
-		if ( $reduce_stock ) {
-			$order_stock_reduced = WC_Vipps_Recurring_Helper::is_stock_reduced_for_order( $order );
-
-			if ( ! $order_stock_reduced ) {
-				WC_Vipps_Recurring_Helper::reduce_stock_for_order( $order );
-			}
-		}
-
-		// status: CHARGED
-		if ( $charge->status === WC_Vipps_Charge::STATUS_CHARGED ) {
-			$this->complete_order( $order, $charge->id );
-
-			/* translators: Vipps/MobilePay Charge ID */
-			$message = sprintf( __( 'Charge completed (Charge ID: %s)', 'woo-vipps' ), $charge->id );
-			$order->add_order_note( $message );
-
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Completed order for charge: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id ) );
-		}
-
-		// status: RESERVED
-		// not auto captured, so we need to put the order status to `$this->default_reserved_charge_status`
-		if ( ! $transaction_id && $charge->status === WC_Vipps_Charge::STATUS_RESERVED
-		     && ! wcs_order_contains_renewal( $order ) ) {
-			WC_Vipps_Recurring_Helper::set_transaction_id_for_order( $order, $charge->id );
-
-			$message = __( 'Waiting for you to capture the payment', 'woo-vipps' );
-			$order->update_status( $this->default_reserved_charge_status, $message );
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Charge reserved: %s (%s)', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id, $charge->status ) );
-		}
-
-		// status: DUE or PENDING
-		// when DUE, we need to check that it becomes another status in a cron
-		$initial = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL )
-		           && ! wcs_order_contains_renewal( $order );
-
-		if ( ! $initial && ! $transaction_id && ( $charge->status === WC_Vipps_Charge::STATUS_DUE
-		                                          || ( $charge->status === WC_Vipps_Charge::STATUS_PENDING
-		                                               && wcs_order_contains_renewal( $order ) ) ) ) {
-			WC_Vipps_Recurring_Helper::set_transaction_id_for_order( $order, $charge->id );
-
-			WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_CAPTURED, true );
-
-			$order->update_status( $this->default_renewal_status, $this->get_due_charge_note( $charge ) );
-
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Charge due or pending: %s (%s)', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id, $charge->status ) );
-		}
-
-		// status: CANCELLED
-		if ( $charge->status === WC_Vipps_Charge::STATUS_CANCELLED ) {
-			$order->update_status( 'cancelled', __( 'Vipps/MobilePay payment cancelled.', 'woo-vipps' ) );
-			WC_Vipps_Recurring_Helper::set_order_as_not_pending( $order );
-
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Charge cancelled: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id ) );
-		}
-
-		// status: FAILED
-		if ( $charge->status === WC_Vipps_Charge::STATUS_FAILED ) {
-			$order->update_status( 'failed', __( 'Vipps/MobilePay payment failed.', 'woo-vipps' ) );
-			WC_Vipps_Recurring_Helper::set_order_charge_failed( $order, $charge );
-
-			// if subscription status is already pending-cancel, we should cancel it completely
-			// this is not WooCommerce Subscription's job as this issue is caused by Vipps' internal retry logic
-			$subscriptions = $this->get_subscriptions_for_order( $order );
-			foreach ( $subscriptions as $subscription ) {
-				if ( $subscription->get_status() !== 'pending-cancel' ) {
-					continue;
-				}
-
-				$subscription->update_status( 'cancelled' );
-			}
-
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Charge failed: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id ) );
-		}
-
-		// if status was FAILED, but no longer is
-		if ( $charge->status !== WC_Vipps_Charge::STATUS_FAILED
-		     && WC_Vipps_Recurring_Helper::is_charge_failed_for_order( $order )
-		     && in_array( $charge->status, [ WC_Vipps_Charge::STATUS_PROCESSING, 'DUE', 'PENDING' ], true ) ) {
-			WC_Vipps_Recurring_Helper::set_order_charge_not_failed( $order, $charge->id );
-		}
-
-		$order->save();
-	}
-
-	/**
-	 * Proceed with current request using new login session (to ensure consistent nonce).
-	 *
-	 * @param $cookie
-	 */
-	public function set_cookie_on_current_request( $cookie ): void {
-		$_COOKIE[ LOGGED_IN_COOKIE ] = $cookie;
-	}
-
-	/**
-	 * Returns all supported currencies for this payment method.
-	 *
-	 * @return array
-	 * @version 4.0.0
-	 * @since 4.0.0
-	 */
-	public function get_supported_currency(): array {
-		return apply_filters(
-			'wc_vipps_recurring_supported_currencies',
-			[
-				'NOK',
-				'DKK',
-				'EUR',
-				'SEK'
-			]
-		);
-	}
-
-	/**
-	 * Checks to see if all criteria is met before showing payment method.
-	 *
-	 * @return bool
-	 * @version 4.0.0
-	 * @since 4.0.0
-	 */
-	public function is_available(): bool {
-		if ( ! in_array( get_woocommerce_currency(), $this->get_supported_currency(), true ) ) {
-			return false;
-		}
-
-		return parent::is_available();
-	}
-
-	/**
-	 * Triggered when it's time to charge a subscription
-	 *
-	 * @param $amount_to_charge
-	 * @param $order
-	 *
-	 * @return bool
-	 *
-	 * @throws Exception
-	 */
-	public function scheduled_subscription_payment( $amount_to_charge, $order ): bool {
-		try {
-			return $this->process_subscription_payment( $amount_to_charge, $order );
-		} catch ( Exception $e ) {
-			// if we reach this point we consider the error to be completely unrecoverable.
-			$order->update_status( 'failed' );
-
-			/* translators: Error message */
-			$message = sprintf( __( 'Failed creating a charge: %s', 'woo-vipps' ), $e->getMessage() );
-			$order->add_order_note( $message );
-
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Error in process_subscription_payment: %s', $order->get_id(), $e->getMessage() ) );
-
-			return false;
-		}
-	}
-
-	/**
-	 * Triggered when a subscription is cancelled
-	 *
-	 * @param $subscription
-	 *
-	 * @throws WC_Vipps_Recurring_Exception
-	 */
-	public function cancel_subscription( $subscription ): void {
-		$payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $subscription );
-		if ( $payment_method !== $this->id ) {
-			// If this is not the payment method, an agreement would not be available.
-			return;
-		}
-
-		// Prevent temporary cancellations from reaching this code
-		$new_status = $subscription->get_status();
-		if ( $new_status !== 'cancelled' ) {
-			return;
-		}
-
-		$subscription_id = WC_Vipps_Recurring_Helper::get_id( $subscription );
-
-		if ( get_transient( 'cancel_subscription_lock' . $subscription_id ) ) {
-			return;
-		}
-
-		set_transient( 'cancel_subscription_lock' . $subscription_id, uniqid( '', true ), 30 );
-
-		$agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $subscription );
-		if ( $agreement_id === null ) {
-			return;
-		}
-
-		$agreement = $this->api->get_agreement( $agreement_id );
-
-		if ( $agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE ) {
-			$this->maybe_handle_subscription_status_transitions( $subscription, $new_status, 'active' );
-			$this->maybe_update_subscription_details_in_app( WC_Vipps_Recurring_Helper::get_id( $subscription ) );
-
-			$idempotency_key = $this->get_idempotency_key( $subscription );
-			$this->api->cancel_agreement( $agreement_id, $idempotency_key );
-		}
-
-		WC_Vipps_Recurring_Logger::log( sprintf( '[%s] cancel_subscription for agreement: %s', $subscription_id, $agreement_id ) );
-	}
-
-	/**
-	 * @param int $order_id
-	 * @param null $amount
-	 * @param string $reason
-	 *
-	 * @throws Exception
-	 */
-	public function process_refund( $order_id, $amount = null, $reason = '' ): ?bool {
-		$order        = wc_get_order( $order_id );
-		$agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
-		$charge_id    = WC_Vipps_Recurring_Helper::get_charge_id_from_order( $order );
-
-		$created = $order->get_date_created( null );
-		if ( $created ) {
-			$diff = ( new DateTime() )->diff( $created );
-
-			if ( $diff->days > 365 ) {
-				/* translators: %s is the days as an integer since the order was created */
-				$err = sprintf( __( 'You cannot refund a charge that was made more than 365 days ago. This order was created %s days ago.', 'woo-vipps' ), $diff->days );
-				throw new \RuntimeException( $err );
-			}
-		}
-
-		try {
-			if ( $amount !== null ) {
-				$amount = WC_Vipps_Recurring_Helper::get_vipps_amount( $amount );
-			}
-
-			$this->api->refund_charge( $agreement_id, $charge_id, $amount, $reason );
-
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_refund for charge: %s and agreement: %s', $order_id, $charge_id, $agreement_id ) );
-
-			return true;
-		} catch ( WC_Vipps_Recurring_Temporary_Exception $e ) {
-			$msg = __( 'A temporary error occurred when refunding a payment through Vipps MobilePay. Please ensure the order is refunded manually or reset the order to "Processing" and try again.', 'woo-vipps' );
-			throw new \RuntimeException( $msg );
-		} catch ( WC_Vipps_Recurring_Exception $e ) {
-			// attempt to cancel charge instead
-			if ( (float) $order->get_remaining_refund_amount() === 0.00 ) {
-				$idempotency_key = $this->get_idempotency_key( $order );
-
-				$this->api->cancel_charge( $agreement_id, $charge_id, $idempotency_key );
-
-				WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, false );
-				$order->save();
-
-				WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_refund cancelled charge instead of refunding: %s and agreement: %s', $order_id, $charge_id, $agreement_id ) );
-
-				return true;
-			}
-
-			// if the remaining refund amount is not equal to the amount we're trying to refund
-			// that probably means we are trying to partially refund a charge that hasn't yet cleared
-			if ( (float) $order->get_remaining_refund_amount() !== 0.00 ) {
-				$err = __( 'You can not partially refund a pending or due charge. Please wait till the payment clears first or refund the full amount instead.', 'woo-vipps' );
-				throw new \RuntimeException( $err );
-			}
-
-			$err = __( 'An unexpected error occurred while refunding a payment in Vipps/MobilePay.', 'woo-vipps' );
-			throw new \RuntimeException( $err );
-		}
-	}
-
-	/**
-	 * @param $order
-	 *
-	 * @return mixed|string
-	 */
-	public function get_idempotency_key( $order ) {
-		$idempotency_key = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_IDEMPOTENCY_KEY );
-
-		if ( ! $idempotency_key ) {
-			$idempotency_key = $this->generate_idempotency_key( $order );
-		}
-
-		return $idempotency_key;
-	}
-
-	/**
-	 * @param $order
-	 *
-	 * @return string
-	 */
-	protected function generate_idempotency_key( $order ): string {
-		$idempotency_key = $this->api->generate_idempotency_key();
-
-		WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_IDEMPOTENCY_KEY, $idempotency_key );
-		$order->save();
-
-		return $idempotency_key;
-	}
-
-	/**
-	 * @param $amount
-	 * @param $renewal_order
-	 *
-	 * @return bool
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 */
-	public function process_subscription_payment( $amount, $renewal_order ): bool {
-		$renewal_order_id = WC_Vipps_Recurring_Helper::get_id( $renewal_order );
-
-		if ( WC_Vipps_Recurring_Helper::order_locked( $renewal_order ) ) {
-			return true;
-		}
-
-		WC_Vipps_Recurring_Helper::lock_order( $renewal_order );
-
-		WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_subscription_payment attempting to create charge', $renewal_order->get_id() ) );
-
-		$agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $renewal_order );
-
-		if ( ! $agreement_id ) {
-			throw new WC_Vipps_Recurring_Exception( 'Fatal error: Vipps/MobilePay agreement id does not exist.' );
-		}
-
-		$agreement = $this->api->get_agreement( $agreement_id );
-		$amount    = WC_Vipps_Recurring_Helper::get_vipps_amount( $amount );
-
-		WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_subscription_payment on agreement: %s', $renewal_order->get_id(), json_encode( $agreement->to_array() ) ) );
-
-		/*
-		 * if this is triggered by the Woo Subscriptions retry system we need to delete the data related to the old payment
-		 * and create an entirely new charge.
-		 */
-		$charge_has_failed = WC_Vipps_Recurring_Helper::is_charge_failed_for_order( $renewal_order );
-
-		// if the previous charge is 'FAILED' we can assume this is an automatic retry instead of a normal renewal process.
-		if ( $charge_has_failed ) {
-			// check that the currently attached charge is in fact failed
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] it looks like the charge on agreement: %s failed. Deleting renewal meta and creating a new charge.', $renewal_order->get_id(), $agreement->id ) );
-
-			// note: delete transaction id as we use this to determine whether to update the order status in check_charge_status.
-			$renewal_order->set_transaction_id( 0 );
-			$renewal_order = $this->delete_renewal_meta( $renewal_order );
-
-			$this->generate_idempotency_key( $renewal_order );
-
-			// clean the post cache for the renewal order to force Woo to fetch meta again.
-			if ( ! $this->use_high_performance_order_storage() ) {
-				clean_post_cache( $renewal_order_id );
-			}
-		}
-
-		$idempotency_key = $this->get_idempotency_key( $renewal_order );
-		$charge          = $this->api->create_charge( $agreement, $idempotency_key, $amount );
-
-		WC_Vipps_Recurring_Helper::update_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $charge['chargeId'] );
-		WC_Vipps_Recurring_Helper::set_order_as_pending( $renewal_order, $charge['chargeId'] );
-
-		WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_subscription_payment created charge: %s', $renewal_order->get_id(), json_encode( $charge ) ) );
-
-		$charge = $this->api->get_charge( $agreement->id, $charge['chargeId'] );
-
-		WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_subscription_payment fetched charge: %s', $renewal_order->get_id(), json_encode( $charge->to_array() ) ) );
-
-		$this->process_order_charge( $renewal_order, $charge );
-		$renewal_order->save();
-
-		WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_subscription_payment for charge: %s and agreement: %s', $renewal_order->get_id(), $charge->id, $agreement->id ) );
-
-		return true;
-	}
-
-	private function get_due_charge_note( WC_Vipps_Charge $charge ): string {
-		$timestamp_gmt   = WC_Vipps_Recurring_Helper::rfc_3999_date_to_unix( $charge->due );
-		$date_to_display = ucfirst( wcs_get_human_time_diff( $timestamp_gmt ) );
-
-		// translators: Vipps/MobilePay Charge ID, human diff timestamp
-		return sprintf( __( 'Vipps/MobilePay charge created: %1$s. The charge will be complete %2$s.', 'woo-vipps' ), $charge->id, strtolower( $date_to_display ) );
-	}
-
-	/**
-	 * Maybe capture a payment if it has not already been captured
-	 *
-	 * @param $order_id
-	 *
-	 * @return bool
-	 * @throws WC_Vipps_Recurring_Exception
-	 */
-	public function maybe_capture_payment( $order_id ): bool {
-		$order = wc_get_order( $order_id );
-
-		if ( ! WC_Vipps_Recurring_Helper::can_capture_charge_for_order( $order ) ) {
-			return false;
-		}
-
-		$this->capture_payment( $order );
-
-		return true;
-	}
-
-	/**
-	 * Capture an initial payment manually
-	 *
-	 * @param $order
-	 *
-	 * @return bool
-	 * @throws WC_Vipps_Recurring_Exception
-	 */
-	public function capture_payment( $order ): bool {
-		$agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
-		$charge_id    = WC_Vipps_Recurring_Helper::get_charge_id_from_order( $order );
-
-		try {
-			$agreement = new WC_Vipps_Agreement( [
-				'id' => $agreement_id
-			] );
-
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Fetching charge to prepare for capture', WC_Vipps_Recurring_Helper::get_id( $order ) ) );
-			$charge = $this->api->get_charge( $agreement->id, $charge_id );
-
-			$idempotency_key = $this->get_idempotency_key( $order );
-
-			if ( $charge->status ) {
-				if ( ! in_array( $charge->status, [
-					WC_Vipps_Charge::STATUS_RESERVED,
-					WC_Vipps_Charge::STATUS_PARTIALLY_CAPTURED
-				] ) ) {
-					WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Charge does not have the status RESERVED or PARTIALLY_CAPTURED for agreement: %s in capture_payment. Found status: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $agreement_id, $charge->status ) );
-					WC_Vipps_Recurring_Helper::set_order_as_not_pending( $order );
-
-					/* translators: %s: The charge's status */
-					$order->add_order_note( sprintf( __( 'Could not capture charge because the status is not RESERVED or PARTIALLY_CAPTURED. Found status: %s', 'woo-vipps' ), $charge->status ) );
-					$order->save();
-
-					return false;
-				}
-			}
-
-			$captured_charge = $this->capture_reserved_charge( $charge, $agreement, $order, $idempotency_key );
-
-			WC_Vipps_Recurring_Helper::set_order_as_pending( $order, $captured_charge->id );
-			$order->save();
-
-			$this->process_order_charge( $order, $captured_charge );
-
-			if ( ! $this->use_high_performance_order_storage() ) {
-				clean_post_cache( WC_Vipps_Recurring_Helper::get_id( $order ) );
-			}
-
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Finished running capture_payment successfully', WC_Vipps_Recurring_Helper::get_id( $order ) ) );
-
-			return true;
-		} catch ( WC_Vipps_Recurring_Temporary_Exception $e ) {
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Temporary error in capture_payment: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $e->getMessage() ) );
-			$this->admin_error( __( 'Vipps/MobilePay is temporarily unavailable.', 'woo-vipps' ) );
-
-			return false;
-		} catch ( WC_Vipps_Recurring_Config_Exception $e ) {
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Configuration error in capture_payment: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $e->getMessage() ) );
-			$this->admin_error( $e->getMessage() );
-
-			return false;
-		}
-	}
-
-	/**
-	 * @param WC_Vipps_Charge $charge
-	 * @param WC_Vipps_Agreement $agreement
-	 * @param $order
-	 * @param string $idempotency_key
-	 */
-	public function capture_reserved_charge( WC_Vipps_Charge $charge, WC_Vipps_Agreement $agreement, $order, string $idempotency_key ): WC_Vipps_Charge {
-		WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Attempting to capture reserve charge: %s for agreement: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id, $agreement->id ) );
-
-		$this->api->capture_reserved_charge( $agreement, $charge, $idempotency_key );
-
-		// Set the charge status manually as we can safely assume it was charged here. This avoids making another API request.
-		$charge->set_status( WC_Vipps_Charge::STATUS_CHARGED );
-
-		WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Captured reserve charge: %s for agreement: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id, $agreement->id ) );
-
-		return $charge;
-	}
-
-	/**
-	 * @param $order
-	 *
-	 * @return array
-	 */
-	public function get_subscriptions_for_order( $order ): array {
-		return WC_Vipps_Recurring_Helper::get_subscriptions_for_order( $order );
-	}
-
-	private function end_gateway_change_checking( $subscription ) {
-		$subscription->delete_meta_data( WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_WAITING_FOR_GATEWAY_CHANGE );
-		$subscription->delete_meta_data( '_new_agreement_id' );
-		$subscription->delete_meta_data( '_old_agreement_id' );
-	}
-
-	/**
-	 * @param $subscription_id
-	 *
-	 * @throws WC_Vipps_Recurring_Exception
-	 */
-	public function maybe_process_gateway_change( $subscription_id ): void {
-		$subscription = wcs_get_subscription( $subscription_id );
-
-		if ( $subscription->meta_exists( '_new_agreement_id' ) ) {
-			$new_agreement_id = WC_Vipps_Recurring_Helper::get_meta( $subscription, '_new_agreement_id' );
-			$agreement        = $this->api->get_agreement( $new_agreement_id );
-
-			if ( $agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE ) {
-				$old_agreement_id = WC_Vipps_Recurring_Helper::get_meta( $subscription, '_old_agreement_id' );
-
-				WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Processing subscription gateway change with new agreement id: %s and old agreement id: %s', WC_Vipps_Recurring_Helper::get_id( $subscription ), $new_agreement_id, $old_agreement_id ) );
-				if ( ! empty( $old_agreement_id ) && $new_agreement_id !== $old_agreement_id ) {
-					WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Cancelling old agreement id: %s in Vipps/MobilePay due to gateway change', WC_Vipps_Recurring_Helper::get_id( $subscription ), $old_agreement_id ) );
-
-					$idempotency_key = $this->get_idempotency_key( $subscription );
-					$this->api->cancel_agreement( $old_agreement_id, $idempotency_key );
-				}
-
-				WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, $new_agreement_id );
-
-				WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Subscription gateway change completed', WC_Vipps_Recurring_Helper::get_id( $subscription ) ) );
-				WC_Subscriptions_Change_Payment_Gateway::update_payment_method( $subscription, $this->id );
-				$this->end_gateway_change_checking( $subscription );
-			}
-
-			if ( in_array( $agreement->status, [ WC_Vipps_Agreement::STATUS_STOPPED, 'EXPIRED' ], true ) ) {
-				$subscription->add_order_note( __( 'Payment gateway change request cancelled in Vipps/MobilePay', 'woo-vipps' ) );
-			}
-
-			if ( in_array( $agreement->status, [
-				WC_Vipps_Agreement::STATUS_STOPPED,
-				WC_Vipps_Agreement::STATUS_EXPIRED
-			], true ) ) {
-				$this->end_gateway_change_checking( $subscription );
-			}
-
-			$subscription->save();
-		}
-	}
-
-	/**
-	 * @param $subscription_id
-	 *
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 */
-	public function maybe_update_subscription_details_in_app( $subscription_id ): void {
-		$subscription = wcs_get_subscription( $subscription_id );
-
-		$payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $subscription );
-		if ( $payment_method !== $this->id ) {
-			return;
-		}
-
-		$agreement = $this->get_agreement_from_order( $subscription );
-		if ( $agreement !== false && $agreement->status !== WC_Vipps_Agreement::STATUS_ACTIVE ) {
-			WC_Vipps_Recurring_Helper::set_update_in_app_completed( $subscription );
-
-			return;
-		}
-
-		$parent_order = $subscription->get_parent();
-		$items        = array_reverse( $subscription->get_items() );
-
-		// we can only ever have one subscription as long as 'multiple_subscriptions' is disabled
-		$item = array_pop( $items );
-
-		if ( ! $item ) {
-			return;
-		}
-
-		$item_name           = $item->get_name();
-		$parent_product      = wc_get_product( $item->get_product_id() );
-		$product_description = WC_Vipps_Recurring_Helper::get_product_description( $parent_product );
-
-		$agreement_description = null;
-		if ( $prefix = WC_Vipps_Recurring_Helper::get_meta( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX ) ) {
-			$agreement_description = "[$prefix]";
-		}
-
-		if ( $product_description ) {
-			$agreement_description .= " $product_description";
-		}
-
-		$updated_agreement = ( new WC_Vipps_Agreement() )
-			->set_pricing( ( new WC_Vipps_Agreement_Pricing() )
-				->set_amount( WC_Vipps_Recurring_Helper::get_vipps_amount( $subscription->get_total() ) ) )
-			->set_product_name( $item_name );
-
-		if ( $agreement_description ) {
-			$updated_agreement = $updated_agreement->set_product_description( $agreement_description );
-		}
-
-		$agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $subscription );
-		if ( empty( $agreement_id ) ) {
-			$agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $parent_order );
-		}
-
-		if ( $agreement_id ) {
-			try {
-				WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Agreement updated in app for agreement id: %s', $subscription_id, $agreement_id ) );
-
-				$idempotency_key = $this->get_idempotency_key( $subscription );
-				$this->api->update_agreement( $agreement_id, $updated_agreement, $idempotency_key );
-			} catch ( Exception $e ) {
-				// do nothing
-			}
-		}
-
-		WC_Vipps_Recurring_Helper::set_update_in_app_completed( $subscription );
-	}
-
-	/**
-	 * @param $order
-	 * @param $subscription
-	 * @param bool $is_gateway_change
-	 *
-	 * @return WC_Vipps_Agreement
-	 * @throws WC_Vipps_Recurring_Invalid_Value_Exception
-	 */
-	public function create_vipps_agreement_from_order( $order, $subscription = null, bool $is_gateway_change = false ): WC_Vipps_Agreement {
-		$order_id = WC_Vipps_Recurring_Helper::get_id( $order );
-
-		if ( ! $subscription ) {
-			$subscription = $order;
-		}
-
-		// This supports not yet having a subscription, purely because of Express and Checkout orders
-		if ( is_a( $subscription, 'WC_Subscription' ) ) {
-			$subscription_period   = $subscription->get_billing_period();
-			$subscription_interval = $subscription->get_billing_interval();
-		} else {
-			$subscription_groups = $this->create_partial_subscription_groups_from_order( $order );
-			$items               = array_pop( $subscription_groups );
-			$product             = $items[0]->get_product();
-
-			$subscription_period   = WC_Subscriptions_Product::get_period( $product );
-			$subscription_interval = WC_Subscriptions_Product::get_interval( $product );
-		}
-
-		$items = array_reverse( $order->get_items() );
-
-		$has_more_products = count( $items ) > 1;
-
-		// we can only ever have one subscription as long as 'multiple_subscriptions' is disabled, so we can fetch the first subscription
-		$subscription_items = array_filter( $items, static function ( $item ) {
-			return apply_filters( 'wc_vipps_recurring_item_is_subscription', WC_Subscriptions_Product::is_subscription( $item['product_id'] ), $item );
-		} );
-
-		$subscription_item = array_pop( $subscription_items );
-		$product           = $subscription_item->get_product();
-		$parent_product    = wc_get_product( $subscription_item->get_product_id() );
-
-		$extra_initial_charge_description = '';
-
-		if ( $has_more_products ) {
-			$other_items = array_filter( $items, static function ( $other_item ) use ( $subscription_item ) {
-				return $subscription_item['product_id'] !== $other_item['product_id'];
-			} );
-
-			foreach ( $other_items as $product_item ) {
-				$extra_initial_charge_description .= WC_Vipps_Recurring_Helper::get_product_description( $product_item->get_product() ) . ', ';
-			}
-
-			$extra_initial_charge_description = rtrim( $extra_initial_charge_description, ', ' );
-		}
-
-		$is_virtual     = $product->is_virtual();
-		$direct_capture = $parent_product->get_meta( WC_Vipps_Recurring_Helper::META_PRODUCT_DIRECT_CAPTURE ) === 'yes';
-
-		$agreement_url = filter_var( get_permalink( get_option( 'woocommerce_myaccount_page_id' ) ), FILTER_VALIDATE_URL )
-			? get_permalink( get_option( 'woocommerce_myaccount_page_id' ) )
-			: wc_get_account_endpoint_url( 'dashboard' );
-
-		if ( ! filter_var( $agreement_url, FILTER_VALIDATE_URL ) ) {
-			$agreement_url = get_home_url();
-		}
-
-		$redirect_url = WC_Vipps_Recurring_Helper::get_payment_redirect_url( $order, $is_gateway_change );
-
-		// total no longer returns the order amount when gateway is being changed
-		$agreement_total = $subscription->get_total( 'code' );
-
-		// when we're performing a variation switch we need some special logic in Vipps
-		$is_subscription_switch = wcs_order_contains_switch( $order );
-
-		if ( $is_subscription_switch ) {
-			$subscription_switch_data = WC_Vipps_Recurring_Helper::get_meta( $order, '_subscription_switch_data' );
-
-			if ( isset( $subscription_switch_data[ array_key_first( $subscription_switch_data ) ]['switches'] ) ) {
-				$switches    = $subscription_switch_data[ array_key_first( $subscription_switch_data ) ]['switches'];
-				$switch_data = $switches[ array_key_first( $switches ) ];
-				$direction   = $switch_data['switch_direction'];
-
-				if ( $direction === 'upgrade' ) {
-					$agreement_total += $order->get_total();
-				}
-			}
-		}
-
-		$has_trial           = WC_Subscriptions_Product::get_trial_length( $product ) !== 0;
-		$is_zero_amount      = (int) $order->get_total() === 0 || $is_gateway_change;
-		$capture_immediately = $is_virtual || $direct_capture;
-		$has_synced_product  = WC_Subscriptions_Synchroniser::subscription_contains_synced_product( $subscription );
-
-		$sign_up_fee       = WC_Subscriptions_Order::get_sign_up_fee( $order );
-		$has_campaign      = $has_trial || $has_synced_product || $is_zero_amount || $order->get_total_discount() !== 0.00 || $is_subscription_switch || $sign_up_fee;
-		$has_free_campaign = $is_subscription_switch || $sign_up_fee || $has_synced_product || $has_trial;
-
-		// when Prorate First Renewal is set to "Never (charge the full recurring amount at sign-up)" we don't want to have a campaign
-		// also not when the order total is the same as the agreement total
-		if ( $has_free_campaign && $has_synced_product && $order->get_total() === $agreement_total ) {
-			$has_campaign = false;
-		}
-
-		$agreement = ( new WC_Vipps_Agreement() )
-			->set_external_id( $order_id )
-			->set_pricing(
-				( new WC_Vipps_Agreement_Pricing() )
-					->set_type( WC_Vipps_Agreement_Pricing::TYPE_LEGACY )
-					->set_currency( $order->get_currency() )
-					->set_amount( apply_filters( 'wc_vipps_recurring_agreement_pricing_amount', WC_Vipps_Recurring_Helper::get_vipps_amount( $agreement_total ), $order ) )
-			)
-			->set_interval(
-				( new WC_Vipps_Agreement_Interval() )
-					->set_unit( strtoupper( $subscription_period ) )
-					->set_count( (int) $subscription_interval )
-			)
-			->set_product_name( $subscription_item->get_name() )
-			->set_merchant_agreement_url( apply_filters( 'wc_vipps_recurring_merchant_agreement_url', $agreement_url ) )
-			->set_merchant_redirect_url( apply_filters( 'wc_vipps_recurring_merchant_redirect_url', $redirect_url ) );
-
-		$product_description = WC_Vipps_Recurring_Helper::get_product_description( $product );
-		if ( $product_description ) {
-			$agreement = $agreement->set_product_description( $product_description );
-		}
-
-		// validate phone number and only add it if it's up to Vipps' standard to avoid errors
-		if ( WC_Vipps_Recurring_Helper::is_valid_phone_number( $order->get_billing_phone() ) ) {
-			$agreement = $agreement->set_phone_number( $order->get_billing_phone() );
-		}
-
-		if ( ! $is_zero_amount ) {
-			$initial_charge_description = WC_Vipps_Recurring_Helper::get_product_description( $parent_product );
-			if ( ! empty( $extra_initial_charge_description ) ) {
-				$initial_charge_description .= ' + ' . $extra_initial_charge_description;
-
-				if ( $has_campaign ) {
-					$initial_charge_description = $extra_initial_charge_description;
-				}
-			}
-
-			$agreement = $agreement->set_initial_charge(
-				( new WC_Vipps_Agreement_Initial_Charge() )
-					->set_amount( apply_filters( 'wc_vipps_recurring_agreement_initial_charge_amount', WC_Vipps_Recurring_Helper::get_vipps_amount( $order->get_total() ), $order ) )
-					->set_description( empty( $initial_charge_description ) ? $subscription_item->get_name() : $initial_charge_description )
-					->set_transaction_type( $capture_immediately ? WC_Vipps_Agreement_Initial_Charge::TRANSACTION_TYPE_DIRECT_CAPTURE : WC_Vipps_Agreement_Initial_Charge::TRANSACTION_TYPE_RESERVE_CAPTURE )
-			);
-
-			WC_Vipps_Recurring_Helper::update_meta_data( $order, $capture_immediately ? WC_Vipps_Recurring_Helper::META_ORDER_DIRECT_CAPTURE : WC_Vipps_Recurring_Helper::META_ORDER_RESERVED_CAPTURE, true );
-		}
-
-		if ( $has_campaign ) {
-			$campaign_price = $has_free_campaign ? $sign_up_fee : $order->get_total();
-
-			$campaign_type   = WC_Vipps_Agreement_Campaign::TYPE_PRICE_CAMPAIGN;
-			$campaign_period = null;
-
-			if ( $has_trial ) {
-				$campaign_type     = WC_Vipps_Agreement_Campaign::TYPE_PERIOD_CAMPAIGN;
-				$campaign_end_date = null;
-				$campaign_period   = ( new WC_Vipps_Agreement_Campaign_Period() )
-					->set_count( WC_Subscriptions_Product::get_trial_length( $product ) )
-					->set_unit( strtoupper( WC_Subscriptions_Product::get_trial_period( $product ) ) );
-			} else {
-				$next_payment = WC_Subscriptions_Product::get_first_renewal_payment_date( $product );
-				$end_date     = WC_Subscriptions_Product::get_expiration_date( $product );
-
-				$campaign_end_date = $end_date === 0 ? $next_payment : $end_date;
-			}
-
-			$agreement = $agreement->set_campaign(
-				( new WC_Vipps_Agreement_Campaign() )
-					->set_type( $campaign_type )
-					->set_price( WC_Vipps_Recurring_Helper::get_vipps_amount( $campaign_price ) )
-					->set_end( $campaign_end_date )
-					->set_period( $campaign_period )
-			);
-		}
-
-		$order->save();
-
-		return apply_filters( 'wc_vipps_recurring_process_payment_agreement', $agreement, $subscription, $order );
-	}
-
-	/**
-	 * Process a payment when checking out in WooCommerce
-	 *
-	 * https://docs.woocommerce.com/document/subscriptions/develop/payment-gateway-integration/
-	 * "Putting it all Together"
-	 *
-	 * @param int $order_id
-	 *
-	 * @throws Exception
-	 */
-	public function process_payment( $order_id, bool $retry = true, bool $previous_error = false ): array {
-		$is_gateway_change = wcs_is_subscription( $order_id );
-
-		$subscription = null;
-
-		$order     = wc_get_order( $order_id );
-		$debug_msg = sprintf( '[%s] process_payment (gateway change: %s)', $order_id, $is_gateway_change ? 'Yes' : 'No' ) . "\n";
-
-		$is_failed_renewal_order = wcs_cart_contains_failed_renewal_order_payment() !== false;
-
-		if ( ! $is_gateway_change
-		     && ! $is_failed_renewal_order
-		     && ! wcs_order_contains_subscription( $order )
-		     && ! wcs_order_contains_early_renewal( $order ) ) {
-			return [
-				'result'   => 'fail',
-				'redirect' => ''
-			];
-		}
-
-		// If we have an early renewal order on our hands we should
-		if ( wcs_order_contains_early_renewal( $order ) ) {
-			$renewal_order = $order;
-
-			$subscriptions = wcs_get_subscriptions_for_renewal_order( $renewal_order );
-			$subscription  = $subscriptions[ array_key_first( $subscriptions ) ];
-
-			$agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $subscription );
-			if ( $agreement_id ) {
-				$existing_agreement = $this->api->get_agreement( $agreement_id );
-
-				if ( $existing_agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE ) {
-					WC_Subscriptions_Payment_Gateways::trigger_gateway_renewal_payment_hook( $renewal_order );
-
-					// Trigger the subscription payment complete hooks and reset suspension counts and user roles.
-					$subscription->payment_complete();
-
-					wcs_update_dates_after_early_renewal( $subscription, $renewal_order );
-					wc_add_notice( __( 'Your early renewal order was successful.', 'woocommerce-subscriptions' ) );
-
-					$renewal_order = wc_get_order( $renewal_order->get_id() );
-
-					return [
-						'result'   => 'success',
-						'redirect' => $renewal_order->get_view_order_url()
-					];
-				}
-			}
-
-			// We need to update the gateway to Vipps/MobilePay after the payment is completed if an agreement is active
-			WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_RENEWING_WITH_VIPPS, true );
-			$subscription->save();
-		}
-
-		try {
-			if ( ! $subscription ) {
-				$subscription = $order;
-			}
-
-			if ( ! $is_gateway_change ) {
-				$subscriptions = $this->get_subscriptions_for_order( $order );
-
-				// we can only ever have one subscription as long as 'multiple_subscriptions' is disabled
-				$subscription = $subscriptions[ array_key_first( $subscriptions ) ];
-			}
-
-			/*
-			 * if this order has a PENDING or ACTIVE agreement in Vipps/MobilePay we should not allow checkout anymore
-			 * this will prevent duplicate transactions
-			 */
-			$agreement_id              = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
-			$already_swapping_to_vipps = WC_Vipps_Recurring_Helper::get_meta( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_WAITING_FOR_GATEWAY_CHANGE );
-
-			if ( $agreement_id && ( ! $is_gateway_change || $already_swapping_to_vipps ) && ! $is_failed_renewal_order ) {
-				if ( ! $already_swapping_to_vipps ) {
-					$existing_agreement = $this->get_agreement_from_order( $order );
-				} else {
-					$new_agreement_id   = WC_Vipps_Recurring_Helper::get_meta( $subscription, '_new_agreement_id' );
-					$existing_agreement = $this->api->get_agreement( $new_agreement_id );
-				}
-
-				if ( $existing_agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE ) {
-					throw new WC_Vipps_Recurring_Temporary_Exception( __( 'This subscription is already active in Vipps/MobilePay. You can leave this page.', 'woo-vipps' ) );
-				}
-			}
-
-			$items = array_reverse( $order->get_items() );
-
-			/*
-			 * WooCommerce Subscriptions should really deal with this themselves, but when other gateways with support for `multiple_subscriptions`
-			 * are enabled WooCommerce Subscriptions allows this scenario for our plugin too. This is not ideal so let's deny it here.
-			 * There's no good way to make this obvious to a customer in the app, especially if the products have different durations
-			 * i.e. one yearly and one monthly
-			 */
-			$has_more_products = count( $items ) > 1;
-			if ( $has_more_products ) {
-				$counter = 1;
-
-				foreach ( $items as $item ) {
-					if ( ! WC_Subscriptions_Product::is_subscription( $item['product_id'] ) ) {
-						continue;
-					}
-
-					if ( $counter > 1 ) {
-						// translators: %s: brand (Vipps or MobilePay)
-						wc_add_notice( sprintf( __( 'Different subscription products can not be purchased at the same time using %s.', 'woo-vipps' ), $this->title ), 'error' );
-
-						return [
-							'result'   => 'fail',
-							'redirect' => ''
-						];
-					}
-
-					$counter ++;
-				}
-			}
-
-			$agreement = $this->create_vipps_agreement_from_order( $order, $subscription, $is_gateway_change );
-
-			$idempotency_key = $this->get_idempotency_key( $order );
-			if ( $is_gateway_change ) {
-				$idempotency_key = $this->api->generate_idempotency_key();
-			}
-
-			$response = $this->api->create_agreement( $agreement, $idempotency_key );
-
-			$is_subscription_switch = wcs_order_contains_switch( $order );
-			$is_zero_amount         = (int) $order->get_total() === 0 || $is_gateway_change;
-
-			// mark the old agreement for cancellation to leave no dangling agreements in Vipps
-			$should_cancel_old = $is_gateway_change || $is_subscription_switch || $is_failed_renewal_order;
-			if ( $should_cancel_old ) {
-				if ( $is_gateway_change ) {
-					/* translators: Vipps/MobilePay Agreement ID */
-					$message = sprintf( __( 'Request to change gateway to Vipps/MobilePay with agreement ID: %s.', 'woo-vipps' ), $response['agreementId'] );
-					$subscription->add_order_note( $message );
-					$debug_msg .= 'Request to change gateway to Vipps' . "\n";
-				} elseif ( $is_subscription_switch ) {
-					$debug_msg .= 'Request to switch subscription variation' . "\n";
-				} else {
-					$debug_msg .= 'Request to pay for a failed renewal order' . "\n";
-				}
-
-				WC_Vipps_Recurring_Helper::update_meta_data( $subscription, '_old_agreement_id', WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $subscription ) );
-				WC_Vipps_Recurring_Helper::update_meta_data( $subscription, '_new_agreement_id', $response['agreementId'] );
-				WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_WAITING_FOR_GATEWAY_CHANGE, true );
-			}
-
-			if ( ! $is_gateway_change ) {
-				if ( ! $should_cancel_old ) {
-					WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, $response['agreementId'] );
-				}
-
-				if ( $is_zero_amount ) {
-					WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_ZERO_AMOUNT, true );
-				}
-
-				WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, $response['agreementId'] );
-				WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, true );
-
-				/* translators: Vipps/MobilePay Agreement ID */
-				$message = sprintf( __( 'Agreement created: %s. Customer sent to Vipps/MobilePay for confirmation.', 'woo-vipps' ), $response['agreementId'] );
-				$order->add_order_note( $message );
-			}
-
-			$debug_msg .= sprintf( 'Created agreement with agreement ID: %s', $response['agreementId'] ) . "\n";
-
-			if ( isset( $response['chargeId'] ) ) {
-				WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $response['chargeId'] );
-			}
-
-			WC_Vipps_Recurring_Helper::delete_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_IS_CHECKOUT );
-			WC_Vipps_Recurring_Helper::delete_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS );
-			WC_Vipps_Recurring_Helper::delete_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_ORDER_IS_CHECKOUT );
-			WC_Vipps_Recurring_Helper::delete_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS );
-
-			// save meta
-			$order->save();
-			$subscription->save();
-
-			$debug_msg .= sprintf( 'Debug body: %s', json_encode( $agreement->to_array() ) ) . "\n";
-			$debug_msg .= sprintf( 'Debug response: %s', json_encode( array_merge( $response, [ 'vippsConfirmationUrl' => 'redacted' ] ) ) );
-			WC_Vipps_Recurring_Logger::log( $debug_msg );
-
-			return [
-				'result'   => 'success',
-				'redirect' => $response['vippsConfirmationUrl'],
-			];
-		} catch ( WC_Vipps_Recurring_Temporary_Exception $e ) {
-			wc_add_notice( $e->getMessage(), 'error' );
-
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Temporary error in process_payment: %s', $order_id, $e->getMessage() ) );
-
-			return [
-				'result'   => 'fail',
-				'redirect' => '',
-			];
-		} catch ( WC_Vipps_Recurring_Exception $e ) {
-			wc_add_notice( $e->getLocalizedMessage(), 'error' );
-
-			$order->update_status( 'failed' );
-
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Error in process_payment: %s', $order_id, $e->getMessage() ) );
-
-			return [
-				'result'   => 'fail',
-				'redirect' => '',
-			];
-		}
-	}
-
-	/**
-	 * All payment icons that work with Vipps. Some icons references
-	 * WC core icons.
-	 *
-	 * @return array
-	 * @since 4.1.0 Changed to using img with svg (colored) instead of fonts.
-	 * @since 4.0.0
-	 */
-	public function payment_icons(): array {
-		return apply_filters(
-			'wc_vipps_recurring_payment_icons',
-			[
-				'vippsmobilepay' => '<img src="' . WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/images/' . $this->brand . '-mark.svg" class="vipps-recurring-icon" alt="' . $this->title . '" />',
-			]
-		);
-	}
-
-	/**
-	 * Get_icon function.
-	 *
-	 * @return string
-	 * @version 4.0.0
-	 * @since 1.0.0
-	 */
-	public function get_icon(): string {
-		$icons = $this->payment_icons();
-
-		return apply_filters( 'woocommerce_gateway_icon', $icons['vippsmobilepay'], $this->id );
-	}
-
-	/**
-	 * @param $key
-	 * @param $data
-	 *
-	 * @return false|string
-	 */
-	public function generate_page_dropdown_html( $key, $data ) {
-		$field_key = $this->get_field_key( $key );
-		$defaults  = [
-			'title'            => '',
-			'class'            => '',
-			'type'             => 'page_dropdown',
-			'desc_tip'         => false,
-			'description'      => '',
-			'show_option_none' => ''
-		];
-
-		$data = wp_parse_args( $data, $defaults );
-
-		$dropdown_pages = wp_dropdown_pages( [
-			'echo'             => 0,
-			'show_option_none' => $data['show_option_none'],
-			'selected'         => $this->get_option( $key ),
-			'id'               => $field_key,
-			'name'             => $field_key,
-			'class'            => $data['class']
-		] );
-
-		ob_start();
-		?>
+    /**
+     * Which brand to use, will be one of: vipps, mobilepay
+     */
+    public string $brand;
+
+    /**
+     * Vipps MobilePay merchant serial number
+     */
+    public string $merchant_serial_number;
+
+    /**
+     * Whether Vipps MobilePay Checkout is enabled
+     */
+    public bool $checkout_enabled;
+
+    public string $order_prefix;
+
+    /**
+     * Is test mode active?
+     */
+    public bool $test_mode;
+
+    /**
+     * The default status to give pending renewals
+     */
+    public string $default_renewal_status;
+
+    /**
+     * The default status pending orders that have yet to be captured (reserved charges in Vipps/MobilePay) should be given
+     */
+    public string $default_reserved_charge_status;
+
+    /**
+     * Status where when transitioned to we will attempt to capture the payment
+     */
+    public array $statuses_to_attempt_capture;
+
+    /**
+     * Transition the order status to 'completed' when a renewal order has been charged successfully
+     * regardless of previous status
+     */
+    public bool $transition_renewals_to_completed;
+
+    /**
+     * The amount of charges to check in wp-cron at a time
+     */
+    public int $check_charges_amount;
+
+    /**
+     * The sort order in which we check charges in wp-cron
+     */
+    public string $check_charges_sort_order;
+
+    /**
+     * The reference the *Singleton* instance of this class
+     */
+    private static ?WC_Gateway_Vipps_Recurring $instance = null;
+
+    public WC_Vipps_Recurring_Api $api;
+
+    public ?bool $use_high_performance_order_storage = null;
+
+    public bool $auto_capture_mobilepay = false;
+
+    public ?string $continue_shopping_link_page = null;
+
+    /**
+     * Returns the *Singleton* instance of this class.
+     *
+     * @return WC_Gateway_Vipps_Recurring The *Singleton* instance.
+     */
+    public static function get_instance(): WC_Gateway_Vipps_Recurring {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        $this->id                 = 'vipps_recurring';
+        $this->method_title       = __( 'Vipps/MobilePay Recurring Payments', 'woo-vipps' );
+        $this->method_description = __( 'Vipps/MobilePay Recurring Payments works by redirecting your customers to the Vipps MobilePay portal for confirmation. It creates a payment plan and charges your users on the intervals you specify.', 'woo-vipps' );
+        $this->has_fields         = true;
+
+        /*
+         * Do not add 'multiple_subscriptions' to $supports.
+         * Vipps/MobilePay Recurring API does not have any concept of multiple line items at the time of writing this.
+         * It could technically be possible to support this, but it's very confusing for a customer in the Vipps/MobilePay app.
+         * There are a lot of edge cases to think about in order to support this functionality too,
+         * 'process_payment' would have to be rewritten entirely.
+         */
+        $this->supports = [
+            'products',
+            'subscriptions',
+            'refunds',
+            'subscription_cancellation',
+            'subscription_suspension',
+            'subscription_reactivation',
+            'subscription_amount_changes',
+            'subscription_date_changes',
+            'subscription_payment_method_change',
+            'subscription_payment_method_change_customer',
+            'subscription_payment_method_change_admin',
+        ];
+
+        // Load the form fields.
+        $this->init_form_fields();
+
+        // Load the settings.
+        $this->init_settings();
+
+        $this->brand                            = $this->get_option( 'brand' );
+        $this->title                            = $this->get_form_fields()['brand']['options'][ $this->brand ];
+        $this->description                      = str_replace( '{brand}', $this->title, $this->get_option( 'description' ) );
+        $this->enabled                          = $this->get_option( 'enabled' );
+        $this->test_mode                        = $this->get_option( 'test_mode' ) === "yes";
+        $this->merchant_serial_number           = $this->get_option( 'merchant_serial_number' );
+        $this->checkout_enabled                 = $this->get_option( 'checkout_enabled' ) === "yes";
+        $this->order_prefix                     = $this->get_option( 'order_prefix' );
+        $this->default_renewal_status           = $this->get_option( 'default_renewal_status' );
+        $this->default_reserved_charge_status   = $this->get_option( 'default_reserved_charge_status' );
+        $this->transition_renewals_to_completed = $this->get_option( 'transition_renewals_to_completed' ) === "yes";
+        $this->check_charges_amount             = $this->get_option( 'check_charges_amount' );
+        $this->check_charges_sort_order         = $this->get_option( 'check_charges_sort_order' );
+        $this->auto_capture_mobilepay           = $this->get_option( 'auto_capture_mobilepay' ) === "yes";
+        $this->continue_shopping_link_page      = $this->get_option( 'continue_shopping_link_page' );
+
+        if ( WC_VIPPS_RECURRING_TEST_MODE ) {
+            $this->test_mode = true;
+        }
+
+        if ( $this->test_mode ) {
+            $this->merchant_serial_number = $this->get_option( 'test_merchant_serial_number' );
+        }
+
+        // translators: %s: brand name, Vipps or MobilePay
+        $this->order_button_text = sprintf( __( 'Pay with %s', 'woo-vipps' ), $this->title );
+
+        $this->api = new WC_Vipps_Recurring_Api( $this );
+
+        /*
+         * When transitioning an order to these statuses we should
+         * automatically try to capture the charge if it's not already captured
+         */
+        $capture_statuses = [
+            'completed',
+            'processing'
+        ];
+
+        /*
+         * We have to remove the status corresponding to `$this->default_reserved_charge_status` otherwise we end up
+         * prematurely capturing this reserved Vipps/MobilePay charge
+         */
+        $capture_status_transition_id = array_search( str_replace( 'wc-', '', $this->default_reserved_charge_status ), $capture_statuses, true );
+        if ( $capture_status_transition_id ) {
+            unset( $capture_statuses[ $capture_status_transition_id ] );
+        }
+
+        $this->statuses_to_attempt_capture = apply_filters( 'wc_vipps_recurring_captured_statuses', $capture_statuses );
+
+        // If we change a status that is currently on-hold to any of the $capture_statuses we should attempt to capture it
+        foreach ( $this->statuses_to_attempt_capture as $status ) {
+            add_action( 'woocommerce_order_status_' . $status, [ $this, 'maybe_capture_payment' ] );
+        }
+
+        add_filter( 'woocommerce_valid_order_statuses_for_payment_complete', [
+            $this,
+            'append_valid_statuses_for_payment_complete'
+        ] );
+
+        add_action( 'woocommerce_order_status_pending_to_cancelled', [ $this, 'maybe_delete_order' ], 99999 );
+        add_action( 'woocommerce_new_order', [ $this, 'maybe_delete_order_later' ] );
+        add_action( 'woocommerce_vipps_recurring_delete_pending_order', [ $this, 'maybe_delete_order' ] );
+
+        add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [
+            $this,
+            'process_admin_options'
+        ] );
+
+        add_action( 'woocommerce_account_view-order_endpoint', [ $this, 'check_charge_status' ], 1 );
+
+        add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
+
+        add_action( 'woocommerce_scheduled_subscription_payment_' . $this->id, [
+            $this,
+            'scheduled_subscription_payment'
+        ], 1, 2 );
+
+        add_action( 'woocommerce_subscription_cancelled_' . $this->id, [
+            $this,
+            'cancel_subscription',
+        ] );
+
+        add_action( 'woocommerce_before_thankyou', [ $this, 'maybe_process_redirect_order' ], 1 );
+
+        add_action( 'woocommerce_subscription_failing_payment_method_updated_' . $this->id, [
+            $this,
+            'update_failing_payment_method'
+        ], 10, 2 );
+
+        /*
+         * When changing the payment method for a WooCommerce Subscription to Vipps MobilePay, let WooCommerce Subscription
+         * know that the payment method for that subscription should not be changed immediately. Instead, it should
+         * wait for the go ahead in cron, after the user confirmed the payment method change with Vipps MobilePay.
+         */
+        add_filter( 'woocommerce_subscriptions_update_payment_via_pay_shortcode', [
+            $this,
+            'indicate_async_payment_method_update'
+        ], 10, 2 );
+
+        // Tell WooCommerce about our custom payment meta fields
+        add_action( 'woocommerce_subscription_payment_meta', [ $this, 'add_subscription_payment_meta' ], 10, 2 );
+
+        // Validate custom payment meta fields
+        add_action( 'woocommerce_subscription_validate_payment_meta', [
+            $this,
+            'validate_subscription_payment_meta'
+        ], 10, 2 );
+
+        // Handle subscription switches (free upgrades & downgrades)
+        add_action( 'woocommerce_subscriptions_switched_item', [ $this, 'handle_subscription_switch_completed' ] );
+
+        // If we are performing a subscription switch to Vipps Recurring we need to take a payment
+        // todo: Figure out how to force a redirect to Vipps here. We do need to sign a new agreement in a lot of cases...
+        // todo: Vipps has a 10x multiplier limit for the agreement pricing.
+        add_filter( 'woocommerce_cart_needs_payment', [ $this, 'cart_needs_payment' ], 100, 2 );
+
+        /*
+         * Handle in app updates when a subscription status changes, typically when status transitions to
+         * 'pending-cancel', 'cancelled' or 'pending-cancel' to any other status
+         */
+        add_action( 'woocommerce_subscription_status_updated', [
+            $this,
+            'maybe_handle_subscription_status_transitions'
+        ], 10, 3 );
+
+        // Delete idempotency key when renewal/resubscribe happens
+        add_action( 'wcs_resubscribe_order_created', [ $this, 'delete_resubscribe_meta' ] );
+        add_action( 'wcs_renewal_order_created', [ $this, 'delete_renewal_meta' ] );
+
+        // Cancel DUE charge if order transitions to 'cancelled' or 'failed'
+        $cancel_due_charge_statuses = apply_filters( 'wc_vipps_recurring_cancel_due_charge_statuses', [
+            'cancelled',
+            'failed'
+        ] );
+
+        foreach ( $cancel_due_charge_statuses as $status ) {
+            add_action( 'woocommerce_order_status_' . $status, [ $this, 'maybe_cancel_due_charge' ] );
+        }
+
+        add_action( 'woocommerce_payment_complete', [ $this, 'after_renew_early_from_another_gateway' ] );
+
+        add_filter( 'woocommerce_payment_complete_order_status', [
+            $this,
+            'prevent_backwards_transition_on_completed_order'
+        ], 100, 3 );
+
+        add_action( 'woocommerce_order_after_calculate_totals', [ $this, 'update_agreement_price_in_app' ], 10, 2 );
+
+        // Woo Subscriptions uses `wp_safe_redirect()` during a gateway change, which will not allow us to redirect to the Vipps MobilePay API
+        // Unless we whitelist the domains specifically
+        // https://developer.vippsmobilepay.com/docs/knowledge-base/servers/
+        add_filter( 'allowed_redirect_hosts', function ( $hosts ) {
+            return array_merge( $hosts, [
+                // Production servers
+                'api.vipps.no',
+                'api.mobilepay.dk',
+                'api.mobilepay.fi',
+                'pay.vipps.no',
+                'pay.mobilepay.dk',
+                'pay.mobilepay.fi',
+                // MT servers
+                'apitest.vipps.no',
+                'pay-mt.vipps.no',
+                'pay-mt.mobilepay.dk',
+                'pay-mt.mobilepay.fi'
+            ] );
+        } );
+    }
+
+    /**
+     * Indicate to WooCommerce Subscriptions that the payment method change for Vipps/MobilePay Recurring Payments
+     * should be asynchronous.
+     *
+     * WC_Subscriptions_Change_Payment_Gateway::change_payment_method_via_pay_shortcode uses the
+     * result to decide whether to change the payment method information on the subscription
+     * right away or not.
+     *
+     * In our case, the payment method will not be updated until after the user confirms the
+     * payment method change with Vipps MobilePay. Once that's done, we'll take care of finishing
+     * the payment method update with the subscription.
+     *
+     * @param bool $should_update Current value of whether the payment method should be updated immediately.
+     * @param string $new_payment_method The new payment method name.
+     *
+     * @return bool Whether the subscription's payment method should be updated on checkout or async when a response is returned.
+     */
+    public function indicate_async_payment_method_update( bool $should_update, string $new_payment_method ): bool {
+        if ( $this->id === $new_payment_method ) {
+            $should_update = false;
+        }
+
+        return $should_update;
+    }
+
+    /**
+     * @param $subscription
+     * @param $renewal_order
+     */
+    public function update_failing_payment_method( $subscription, $renewal_order ): void {
+        WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $renewal_order ) );
+    }
+
+    /**
+     * @param $order_id
+     *
+     * @throws WC_Vipps_Recurring_Exception
+     */
+    public function process_redirect_payment( $order_id ): void {
+        $order = wc_get_order( $order_id );
+        if ( ! is_object( $order ) ) {
+            return;
+        }
+
+        $payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $order );
+        if ( $payment_method !== $this->id ) {
+            // If this is not the payment method, an agreement would not be available.
+            return;
+        }
+
+        // check latest charge status
+        $status = $this->check_charge_status( $order_id );
+
+        WC_Vipps_Recurring_Logger::log( sprintf( "[%s] process_redirect_payment: charge status is: %s", $order_id, $status ) );
+    }
+
+    /**
+     * @param $order_id
+     *
+     * @throws WC_Vipps_Recurring_Exception
+     */
+    public function maybe_process_redirect_order( $order_id ): void {
+        if ( ! is_order_received_page() ) {
+            return;
+        }
+
+        $order = wc_get_order( $order_id );
+        if ( $order->get_payment_method() !== $this->id ) {
+            return;
+        }
+
+        $this->process_redirect_payment( $order_id );
+    }
+
+    /**
+     * Check if we are using the new HPOS feature from WooCommerce
+     * This function is used for backwards compatibility in certain places
+     */
+    public function use_high_performance_order_storage(): bool {
+        if ( $this->use_high_performance_order_storage === null ) {
+            $this->use_high_performance_order_storage = function_exists( 'wc_get_container' ) &&  // 4.4.0
+                                                        function_exists( 'wc_get_page_screen_id' ) && // Exists in the HPOS update
+                                                        class_exists( "Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController" ) &&
+                                                        wc_get_container()->get( Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
+        }
+
+        return $this->use_high_performance_order_storage;
+    }
+
+    /**
+     * Retrieves the latest charge for an order if any. False if none or invalid agreement id
+     *
+     * @param $order
+     *
+     * @return bool|WC_Vipps_Charge
+     * @throws WC_Vipps_Recurring_Exception
+     */
+    public function get_latest_charge_from_order( $order ) {
+        $agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
+
+        if ( ! $agreement_id ) {
+            return false;
+        }
+
+        $charge_id = WC_Vipps_Recurring_Helper::get_charge_id_from_order( $order );
+        $charge    = false;
+
+        if ( $charge_id ) {
+            try {
+                $charge = $this->api->get_charge( $agreement_id, $charge_id );
+            } catch ( WC_Vipps_Recurring_Temporary_Exception $e ) {
+                // do nothing, we're just being too quick
+            } catch ( Exception $e ) {
+                $charge = $this->get_latest_charge_for_agreement( $order, $agreement_id, $charge_id );
+            }
+        } else {
+            $charge = $this->get_latest_charge_for_agreement( $order, $agreement_id, $charge_id );
+        }
+
+        return $charge;
+    }
+
+    /**
+     * @param object|WC_Order $order
+     * @param string $agreement_id
+     * @param string $charge_id
+     *
+     * @return false|null|WC_Vipps_Charge
+     * @throws WC_Vipps_Recurring_Config_Exception
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     */
+    public function get_latest_charge_for_agreement( $order, string $agreement_id, string $charge_id ) {
+        WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Failed checking charge directly for charge: %s and agreement: %s. This might mean we have not set the right charge id somewhere. Finding latest charge instead.', WC_Vipps_Recurring_Helper::get_id( $order ), $charge_id, $agreement_id ) );
+
+        $charges = $this->api->get_charges_for( $agreement_id );
+
+        // return false if there is no charge
+        // this will tell us if this was directly captured or not
+        if ( count( $charges ) === 0 ) {
+            return false;
+        }
+
+        $charge = null;
+        if ( $charges ) {
+            $charge = array_reverse( $charges )[0];
+        }
+
+        return $charge;
+    }
+
+    /**
+     * Receives the agreement associated with an order
+     *
+     * @param object|WC_Order $order
+     *
+     * @return bool|WC_Vipps_Agreement
+     * @throws WC_Vipps_Recurring_Exception
+     */
+    public function get_agreement_from_order( $order ) {
+        $agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
+
+        if ( ! $agreement_id ) {
+            return false;
+        }
+
+        return $this->api->get_agreement( $agreement_id );
+    }
+
+    /**
+     * @param object|WC_Order $order
+     */
+    public function unlock_order( $order ): void {
+        WC_Vipps_Recurring_Helper::update_meta_data( $order, '_vipps_recurring_locked_for_update_time', 0 );
+        $order->save();
+    }
+
+    /**
+     * @param $order_id
+     * @param bool $skip_lock
+     *
+     * @return string
+     * @throws WC_Vipps_Recurring_Config_Exception
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     */
+    public function check_charge_status( $order_id, $skip_lock = false ): string {
+        if ( empty( $order_id ) || absint( $order_id ) <= 0 ) {
+            return 'INVALID';
+        }
+
+        $order = wc_get_order( absint( $order_id ) );
+
+        $payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $order );
+        if ( $payment_method !== $this->id ) {
+            // if this is not the payment method, an agreement would not be available.
+            return 'INVALID';
+        }
+
+        // we need to tell WooCommerce that this is in fact a scheduled payment that should be retried in the case of failure.
+        if ( wcs_order_contains_renewal( $order ) ) {
+            add_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
+        }
+
+        // check if order is temporarily locked
+        if ( ! $this->use_high_performance_order_storage() ) {
+            clean_post_cache( WC_Vipps_Recurring_Helper::get_id( $order ) );
+        }
+
+        // hold on to the lock for 30 seconds
+        $lock = (int) WC_Vipps_Recurring_Helper::get_meta( $order, '_vipps_recurring_locked_for_update_time' );
+        if ( ( $lock && $lock > time() - 30 ) && ! $skip_lock ) {
+            return 'SUCCESS';
+        }
+
+        // lock the order
+        WC_Vipps_Recurring_Helper::update_meta_data( $order, '_vipps_recurring_locked_for_update_time', time() );
+        $order->save();
+
+        $agreement = $this->get_agreement_from_order( $order );
+        if ( ! $agreement ) {
+            // If there is no agreement we can't complete Checkout orders. Let Checkout deal with this through an action.
+            $order_initial = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL );
+
+            if ( $order_initial && $order->get_payment_method() === $this->id ) {
+                do_action( 'wc_vipps_recurring_check_charge_status_no_agreement', $order );
+            }
+
+            return 'INVALID';
+        }
+
+        $is_renewal = wcs_order_contains_renewal( $order );
+
+        // logic for zero amounts when a charge does not exist
+        if ( WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_ZERO_AMOUNT ) && ! $is_renewal ) {
+            // if there's a campaign with a price of 0 we can complete the order immediately
+            if ( $agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE ) {
+                $this->complete_order( $order, $agreement->id );
+
+                $order->add_order_note( __( 'The subtotal is zero, the order is free for this subscription period.', 'woo-vipps' ) );
+                $order->save();
+            }
+
+            // if EXPIRED or STOPPED we can fail this order
+            if ( in_array( $agreement->status, [
+                WC_Vipps_Agreement::STATUS_EXPIRED,
+                WC_Vipps_Agreement::STATUS_STOPPED
+            ], true ) ) {
+                $this->check_charge_agreement_cancelled( $order, $agreement );
+
+                return 'CANCELLED';
+            }
+
+            return 'SUCCESS';
+        }
+
+        $charge = $this->get_latest_charge_from_order( $order );
+
+        if ( ! $charge ) {
+            // we're being rate limited
+            return 'SUCCESS';
+        }
+
+        // set _charge_id on order
+        WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $charge->id );
+
+        // set _vipps_recurring_latest_api_status
+        WC_Vipps_Recurring_Helper::set_latest_api_status_for_order( $order, $charge->status );
+
+        $initial        = empty( WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL ) )
+                          && ! wcs_order_contains_renewal( $order );
+        $pending_charge = $initial ? 1 : (int) WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING );
+        $did_fail       = WC_Vipps_Recurring_Helper::is_charge_failed_for_order( $order );
+
+        // If payment has already been captured, this function is redundant, unless the charge failed
+        if ( ! $pending_charge && ! $did_fail ) {
+            $this->unlock_order( $order );
+
+            return 'SUCCESS';
+        }
+
+        $is_captured = ! in_array( $charge->status, [
+                WC_Vipps_Charge::STATUS_PENDING,
+                WC_Vipps_Charge::STATUS_RESERVED
+            ], true ) && $agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE;
+
+        // If the brand is MobilePay, we should capture the payment now if it is not already captured.
+        // This is because MobilePay auto-releases and refunds payments after 7 days. Vipps will keep a reservation for a lot longer.
+        if ( $this->brand === WC_Vipps_Recurring_Helper::BRAND_MOBILEPAY
+             && ! $is_captured
+             && $this->auto_capture_mobilepay ) {
+            $order->save();
+
+            if ( $this->maybe_capture_payment( $order_id ) ) {
+                $order->add_order_note( __( 'MobilePay payments are automatically captured to prevent the payment reservation from automatically getting cancelled after 14 days.', 'woo-vipps' ) );
+
+                return 'SUCCESS';
+            }
+        }
+
+        $is_direct_capture = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_DIRECT_CAPTURE );
+        if ( $is_direct_capture && ! $is_captured ) {
+            $order->save();
+
+            $this->maybe_capture_payment( $order_id );
+
+            return 'SUCCESS';
+        }
+
+        WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_CAPTURED, $is_captured );
+
+        if ( (int) $initial ) {
+            WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL, true );
+            WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, true );
+        }
+
+        $this->unlock_order( $order );
+
+        $order->save();
+
+        if ( ! $this->use_high_performance_order_storage() ) {
+            clean_post_cache( WC_Vipps_Recurring_Helper::get_id( $order ) );
+        }
+
+        $this->process_order_charge( $order, $charge );
+
+        // agreement is expired or stopped
+        if ( in_array( $agreement->status, [
+            WC_Vipps_Agreement::STATUS_STOPPED,
+            WC_Vipps_Agreement::STATUS_EXPIRED
+        ], true ) ) {
+            $this->check_charge_agreement_cancelled( $order, $agreement, $charge );
+
+            return 'CANCELLED';
+        }
+
+        return 'SUCCESS';
+    }
+
+    /**
+     * @param $order
+     * @param WC_Vipps_Agreement $agreement
+     * @param bool|WC_Vipps_Charge $charge
+     *
+     * @throws WC_Vipps_Recurring_Config_Exception
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     */
+    public function check_charge_agreement_cancelled( $order, WC_Vipps_Agreement $agreement, $charge = false ): void {
+        $order->update_status( 'cancelled', __( 'The agreement was cancelled or expired in Vipps/MobilePay', 'woo-vipps' ) );
+
+        WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, false );
+        $order->save();
+
+        // cancel charge
+        if ( $charge && in_array( $charge->status, [
+                WC_Vipps_Charge::STATUS_DUE,
+                WC_Vipps_Charge::STATUS_PENDING
+            ], true ) ) {
+            $idempotency_key = $this->get_idempotency_key( $order );
+
+            $this->api->cancel_charge( $agreement->id, $charge->id, $idempotency_key );
+        }
+    }
+
+    /**
+     * @param $order
+     * @param $transaction_id
+     */
+    public function complete_order( $order, $transaction_id ): void {
+        $order->payment_complete( $transaction_id );
+
+        // Controlled by the `transition_renewals_to_completed` setting
+        // Only applicable to renewal orders
+        if ( $this->transition_renewals_to_completed && wcs_order_contains_renewal( $order ) && $order->get_status() !== 'completed' ) {
+            $order->update_status( 'completed' );
+        }
+
+        // Unlock the order and make sure we tell our cronjob to stop periodically checking the status of this order
+        WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, false );
+        $this->unlock_order( $order );
+
+        if ( is_callable( [ $order, 'save' ] ) ) {
+            $order->save();
+        }
+
+        do_action( 'wc_vipps_recurring_after_payment_complete', $order );
+    }
+
+    /**
+     * @param $order
+     * @param WC_Vipps_Charge|null $charge
+     */
+    public function process_order_charge( $order, ?WC_Vipps_Charge $charge = null ): void {
+        if ( ! $charge ) {
+            // No charge
+            return;
+        }
+
+        // If payment has already been completed, this function is redundant.
+        if ( ! WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING ) ) {
+            return;
+        }
+
+        do_action( 'wc_vipps_recurring_before_process_order_charge', $order );
+
+        WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $charge->id );
+        $transaction_id = WC_Vipps_Recurring_Helper::get_transaction_id_for_order( $order );
+
+        // Reduce stock
+        $reduce_stock = $charge->status === WC_Vipps_Charge::STATUS_CHARGED || in_array( $charge->status, [
+                WC_Vipps_Charge::STATUS_DUE,
+                WC_Vipps_Charge::STATUS_PENDING
+            ], true );
+
+        if ( $reduce_stock ) {
+            $order_stock_reduced = WC_Vipps_Recurring_Helper::is_stock_reduced_for_order( $order );
+
+            if ( ! $order_stock_reduced ) {
+                WC_Vipps_Recurring_Helper::reduce_stock_for_order( $order );
+            }
+        }
+
+        // status: CHARGED
+        if ( $charge->status === WC_Vipps_Charge::STATUS_CHARGED ) {
+            $this->complete_order( $order, $charge->id );
+
+            /* translators: Vipps/MobilePay Charge ID */
+            $message = sprintf( __( 'Charge completed (Charge ID: %s)', 'woo-vipps' ), $charge->id );
+            $order->add_order_note( $message );
+
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Completed order for charge: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id ) );
+        }
+
+        // status: RESERVED
+        // not auto captured, so we need to put the order status to `$this->default_reserved_charge_status`
+        if ( ! $transaction_id && $charge->status === WC_Vipps_Charge::STATUS_RESERVED
+             && ! wcs_order_contains_renewal( $order ) ) {
+            WC_Vipps_Recurring_Helper::set_transaction_id_for_order( $order, $charge->id );
+
+            $message = __( 'Waiting for you to capture the payment', 'woo-vipps' );
+            $order->update_status( $this->default_reserved_charge_status, $message );
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Charge reserved: %s (%s)', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id, $charge->status ) );
+        }
+
+        // status: DUE or PENDING
+        // when DUE, we need to check that it becomes another status in a cron
+        $initial = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL )
+                   && ! wcs_order_contains_renewal( $order );
+
+        if ( ! $initial && ! $transaction_id && ( $charge->status === WC_Vipps_Charge::STATUS_DUE
+                                                  || ( $charge->status === WC_Vipps_Charge::STATUS_PENDING
+                                                       && wcs_order_contains_renewal( $order ) ) ) ) {
+            WC_Vipps_Recurring_Helper::set_transaction_id_for_order( $order, $charge->id );
+
+            WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_CAPTURED, true );
+
+            $order->update_status( $this->default_renewal_status, $this->get_due_charge_note( $charge ) );
+
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Charge due or pending: %s (%s)', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id, $charge->status ) );
+        }
+
+        // status: CANCELLED
+        if ( $charge->status === WC_Vipps_Charge::STATUS_CANCELLED ) {
+            $order->update_status( 'cancelled', __( 'Vipps/MobilePay payment cancelled.', 'woo-vipps' ) );
+            WC_Vipps_Recurring_Helper::set_order_as_not_pending( $order );
+
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Charge cancelled: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id ) );
+        }
+
+        // status: FAILED
+        if ( $charge->status === WC_Vipps_Charge::STATUS_FAILED ) {
+            $order->update_status( 'failed', __( 'Vipps/MobilePay payment failed.', 'woo-vipps' ) );
+            WC_Vipps_Recurring_Helper::set_order_charge_failed( $order, $charge );
+
+            // if subscription status is already pending-cancel, we should cancel it completely
+            // this is not WooCommerce Subscription's job as this issue is caused by Vipps' internal retry logic
+            $subscriptions = $this->get_subscriptions_for_order( $order );
+            foreach ( $subscriptions as $subscription ) {
+                if ( $subscription->get_status() !== 'pending-cancel' ) {
+                    continue;
+                }
+
+                $subscription->update_status( 'cancelled' );
+            }
+
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Charge failed: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id ) );
+        }
+
+        // if status was FAILED, but no longer is
+        if ( $charge->status !== WC_Vipps_Charge::STATUS_FAILED
+             && WC_Vipps_Recurring_Helper::is_charge_failed_for_order( $order )
+             && in_array( $charge->status, [ WC_Vipps_Charge::STATUS_PROCESSING, 'DUE', 'PENDING' ], true ) ) {
+            WC_Vipps_Recurring_Helper::set_order_charge_not_failed( $order, $charge->id );
+        }
+
+        $order->save();
+    }
+
+    /**
+     * Proceed with current request using new login session (to ensure consistent nonce).
+     *
+     * @param $cookie
+     */
+    public function set_cookie_on_current_request( $cookie ): void {
+        $_COOKIE[ LOGGED_IN_COOKIE ] = $cookie;
+    }
+
+    /**
+     * Returns all supported currencies for this payment method.
+     *
+     * @return array
+     * @version 4.0.0
+     * @since 4.0.0
+     */
+    public function get_supported_currency(): array {
+        return apply_filters(
+            'wc_vipps_recurring_supported_currencies',
+            [
+                'NOK',
+                'DKK',
+                'EUR',
+                'SEK'
+            ]
+        );
+    }
+
+    /**
+     * Checks to see if all criteria is met before showing payment method.
+     *
+     * @return bool
+     * @version 4.0.0
+     * @since 4.0.0
+     */
+    public function is_available(): bool {
+        if ( ! in_array( get_woocommerce_currency(), $this->get_supported_currency(), true ) ) {
+            return false;
+        }
+
+        return parent::is_available();
+    }
+
+    /**
+     * Triggered when it's time to charge a subscription
+     *
+     * @param $amount_to_charge
+     * @param $order
+     *
+     * @return bool
+     *
+     * @throws Exception
+     */
+    public function scheduled_subscription_payment( $amount_to_charge, $order ): bool {
+        try {
+            return $this->process_subscription_payment( $amount_to_charge, $order );
+        } catch ( Exception $e ) {
+            // if we reach this point we consider the error to be completely unrecoverable.
+            $order->update_status( 'failed' );
+
+            /* translators: Error message */
+            $message = sprintf( __( 'Failed creating a charge: %s', 'woo-vipps' ), $e->getMessage() );
+            $order->add_order_note( $message );
+
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Error in process_subscription_payment: %s', $order->get_id(), $e->getMessage() ) );
+
+            return false;
+        }
+    }
+
+    /**
+     * Triggered when a subscription is cancelled
+     *
+     * @param $subscription
+     *
+     * @throws WC_Vipps_Recurring_Exception
+     */
+    public function cancel_subscription( $subscription ): void {
+        $payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $subscription );
+        if ( $payment_method !== $this->id ) {
+            // If this is not the payment method, an agreement would not be available.
+            return;
+        }
+
+        // Prevent temporary cancellations from reaching this code
+        $new_status = $subscription->get_status();
+        if ( $new_status !== 'cancelled' ) {
+            return;
+        }
+
+        $subscription_id = WC_Vipps_Recurring_Helper::get_id( $subscription );
+
+        if ( get_transient( 'cancel_subscription_lock' . $subscription_id ) ) {
+            return;
+        }
+
+        set_transient( 'cancel_subscription_lock' . $subscription_id, uniqid( '', true ), 30 );
+
+        $agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $subscription );
+        if ( $agreement_id === null ) {
+            return;
+        }
+
+        $agreement = $this->api->get_agreement( $agreement_id );
+
+        if ( $agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE ) {
+            $this->maybe_handle_subscription_status_transitions( $subscription, $new_status, 'active' );
+            $this->maybe_update_subscription_details_in_app( WC_Vipps_Recurring_Helper::get_id( $subscription ) );
+
+            $idempotency_key = $this->get_idempotency_key( $subscription );
+            $this->api->cancel_agreement( $agreement_id, $idempotency_key );
+        }
+
+        WC_Vipps_Recurring_Logger::log( sprintf( '[%s] cancel_subscription for agreement: %s', $subscription_id, $agreement_id ) );
+    }
+
+    /**
+     * @param int $order_id
+     * @param null $amount
+     * @param string $reason
+     *
+     * @throws Exception
+     */
+    public function process_refund( $order_id, $amount = null, $reason = '' ): ?bool {
+        $order        = wc_get_order( $order_id );
+        $agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
+        $charge_id    = WC_Vipps_Recurring_Helper::get_charge_id_from_order( $order );
+
+        $created = $order->get_date_created( null );
+        if ( $created ) {
+            $diff = ( new DateTime() )->diff( $created );
+
+            if ( $diff->days > 365 ) {
+                /* translators: %s is the days as an integer since the order was created */
+                $err = sprintf( __( 'You cannot refund a charge that was made more than 365 days ago. This order was created %s days ago.', 'woo-vipps' ), $diff->days );
+                throw new \RuntimeException( $err );
+            }
+        }
+
+        try {
+            if ( $amount !== null ) {
+                $amount = WC_Vipps_Recurring_Helper::get_vipps_amount( $amount );
+            }
+
+            $this->api->refund_charge( $agreement_id, $charge_id, $amount, $reason );
+
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_refund for charge: %s and agreement: %s', $order_id, $charge_id, $agreement_id ) );
+
+            return true;
+        } catch ( WC_Vipps_Recurring_Temporary_Exception $e ) {
+            $msg = __( 'A temporary error occurred when refunding a payment through Vipps MobilePay. Please ensure the order is refunded manually or reset the order to "Processing" and try again.', 'woo-vipps' );
+            throw new \RuntimeException( $msg );
+        } catch ( WC_Vipps_Recurring_Exception $e ) {
+            // attempt to cancel charge instead
+            if ( (float) $order->get_remaining_refund_amount() === 0.00 ) {
+                $idempotency_key = $this->get_idempotency_key( $order );
+
+                $this->api->cancel_charge( $agreement_id, $charge_id, $idempotency_key );
+
+                WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, false );
+                $order->save();
+
+                WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_refund cancelled charge instead of refunding: %s and agreement: %s', $order_id, $charge_id, $agreement_id ) );
+
+                return true;
+            }
+
+            // if the remaining refund amount is not equal to the amount we're trying to refund
+            // that probably means we are trying to partially refund a charge that hasn't yet cleared
+            if ( (float) $order->get_remaining_refund_amount() !== 0.00 ) {
+                $err = __( 'You can not partially refund a pending or due charge. Please wait till the payment clears first or refund the full amount instead.', 'woo-vipps' );
+                throw new \RuntimeException( $err );
+            }
+
+            $err = __( 'An unexpected error occurred while refunding a payment in Vipps/MobilePay.', 'woo-vipps' );
+            throw new \RuntimeException( $err );
+        }
+    }
+
+    /**
+     * @param $order
+     *
+     * @return mixed|string
+     */
+    public function get_idempotency_key( $order ) {
+        $idempotency_key = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_IDEMPOTENCY_KEY );
+
+        if ( ! $idempotency_key ) {
+            $idempotency_key = $this->generate_idempotency_key( $order );
+        }
+
+        return $idempotency_key;
+    }
+
+    /**
+     * @param $order
+     *
+     * @return string
+     */
+    protected function generate_idempotency_key( $order ): string {
+        $idempotency_key = $this->api->generate_idempotency_key();
+
+        WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_IDEMPOTENCY_KEY, $idempotency_key );
+        $order->save();
+
+        return $idempotency_key;
+    }
+
+    /**
+     * @param $amount
+     * @param $renewal_order
+     *
+     * @return bool
+     * @throws WC_Vipps_Recurring_Config_Exception
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     */
+    public function process_subscription_payment( $amount, $renewal_order ): bool {
+        $renewal_order_id = WC_Vipps_Recurring_Helper::get_id( $renewal_order );
+
+        if ( WC_Vipps_Recurring_Helper::order_locked( $renewal_order ) ) {
+            return true;
+        }
+
+        WC_Vipps_Recurring_Helper::lock_order( $renewal_order );
+
+        WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_subscription_payment attempting to create charge', $renewal_order->get_id() ) );
+
+        $agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $renewal_order );
+
+        if ( ! $agreement_id ) {
+            throw new WC_Vipps_Recurring_Exception( 'Fatal error: Vipps/MobilePay agreement id does not exist.' );
+        }
+
+        $agreement = $this->api->get_agreement( $agreement_id );
+        $amount    = WC_Vipps_Recurring_Helper::get_vipps_amount( $amount );
+
+        WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_subscription_payment on agreement: %s', $renewal_order->get_id(), json_encode( $agreement->to_array() ) ) );
+
+        /*
+         * if this is triggered by the Woo Subscriptions retry system we need to delete the data related to the old payment
+         * and create an entirely new charge.
+         */
+        $charge_has_failed = WC_Vipps_Recurring_Helper::is_charge_failed_for_order( $renewal_order );
+
+        // if the previous charge is 'FAILED' we can assume this is an automatic retry instead of a normal renewal process.
+        if ( $charge_has_failed ) {
+            // check that the currently attached charge is in fact failed
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] it looks like the charge on agreement: %s failed. Deleting renewal meta and creating a new charge.', $renewal_order->get_id(), $agreement->id ) );
+
+            // note: delete transaction id as we use this to determine whether to update the order status in check_charge_status.
+            $renewal_order->set_transaction_id( 0 );
+            $renewal_order = $this->delete_renewal_meta( $renewal_order );
+
+            $this->generate_idempotency_key( $renewal_order );
+
+            // clean the post cache for the renewal order to force Woo to fetch meta again.
+            if ( ! $this->use_high_performance_order_storage() ) {
+                clean_post_cache( $renewal_order_id );
+            }
+        }
+
+        $idempotency_key = $this->get_idempotency_key( $renewal_order );
+        $charge          = $this->api->create_charge( $agreement, $idempotency_key, $amount );
+
+        WC_Vipps_Recurring_Helper::update_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $charge['chargeId'] );
+        WC_Vipps_Recurring_Helper::set_order_as_pending( $renewal_order, $charge['chargeId'] );
+
+        WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_subscription_payment created charge: %s', $renewal_order->get_id(), json_encode( $charge ) ) );
+
+        $charge = $this->api->get_charge( $agreement->id, $charge['chargeId'] );
+
+        WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_subscription_payment fetched charge: %s', $renewal_order->get_id(), json_encode( $charge->to_array() ) ) );
+
+        $this->process_order_charge( $renewal_order, $charge );
+        $renewal_order->save();
+
+        WC_Vipps_Recurring_Logger::log( sprintf( '[%s] process_subscription_payment for charge: %s and agreement: %s', $renewal_order->get_id(), $charge->id, $agreement->id ) );
+
+        return true;
+    }
+
+    private function get_due_charge_note( WC_Vipps_Charge $charge ): string {
+        $timestamp_gmt   = WC_Vipps_Recurring_Helper::rfc_3999_date_to_unix( $charge->due );
+        $date_to_display = ucfirst( wcs_get_human_time_diff( $timestamp_gmt ) );
+
+        // translators: Vipps/MobilePay Charge ID, human diff timestamp
+        return sprintf( __( 'Vipps/MobilePay charge created: %1$s. The charge will be complete %2$s.', 'woo-vipps' ), $charge->id, strtolower( $date_to_display ) );
+    }
+
+    /**
+     * Maybe capture a payment if it has not already been captured
+     *
+     * @param $order_id
+     *
+     * @return bool
+     * @throws WC_Vipps_Recurring_Exception
+     */
+    public function maybe_capture_payment( $order_id ): bool {
+        $order = wc_get_order( $order_id );
+
+        if ( ! WC_Vipps_Recurring_Helper::can_capture_charge_for_order( $order ) ) {
+            return false;
+        }
+
+        $this->capture_payment( $order );
+
+        return true;
+    }
+
+    /**
+     * Capture an initial payment manually
+     *
+     * @param $order
+     *
+     * @return bool
+     * @throws WC_Vipps_Recurring_Exception
+     */
+    public function capture_payment( $order ): bool {
+        $agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
+        $charge_id    = WC_Vipps_Recurring_Helper::get_charge_id_from_order( $order );
+
+        try {
+            $agreement = new WC_Vipps_Agreement( [
+                'id' => $agreement_id
+            ] );
+
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Fetching charge to prepare for capture', WC_Vipps_Recurring_Helper::get_id( $order ) ) );
+            $charge = $this->api->get_charge( $agreement->id, $charge_id );
+
+            $idempotency_key = $this->get_idempotency_key( $order );
+
+            if ( $charge->status ) {
+                if ( ! in_array( $charge->status, [
+                    WC_Vipps_Charge::STATUS_RESERVED,
+                    WC_Vipps_Charge::STATUS_PARTIALLY_CAPTURED
+                ] ) ) {
+                    WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Charge does not have the status RESERVED or PARTIALLY_CAPTURED for agreement: %s in capture_payment. Found status: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $agreement_id, $charge->status ) );
+                    WC_Vipps_Recurring_Helper::set_order_as_not_pending( $order );
+
+                    /* translators: %s: The charge's status */
+                    $order->add_order_note( sprintf( __( 'Could not capture charge because the status is not RESERVED or PARTIALLY_CAPTURED. Found status: %s', 'woo-vipps' ), $charge->status ) );
+                    $order->save();
+
+                    return false;
+                }
+            }
+
+            $captured_charge = $this->capture_reserved_charge( $charge, $agreement, $order, $idempotency_key );
+
+            WC_Vipps_Recurring_Helper::set_order_as_pending( $order, $captured_charge->id );
+            $order->save();
+
+            $this->process_order_charge( $order, $captured_charge );
+
+            if ( ! $this->use_high_performance_order_storage() ) {
+                clean_post_cache( WC_Vipps_Recurring_Helper::get_id( $order ) );
+            }
+
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Finished running capture_payment successfully', WC_Vipps_Recurring_Helper::get_id( $order ) ) );
+
+            return true;
+        } catch ( WC_Vipps_Recurring_Temporary_Exception $e ) {
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Temporary error in capture_payment: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $e->getMessage() ) );
+            $this->admin_error( __( 'Vipps/MobilePay is temporarily unavailable.', 'woo-vipps' ) );
+
+            return false;
+        } catch ( WC_Vipps_Recurring_Config_Exception $e ) {
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Configuration error in capture_payment: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $e->getMessage() ) );
+            $this->admin_error( $e->getMessage() );
+
+            return false;
+        }
+    }
+
+    /**
+     * @param WC_Vipps_Charge $charge
+     * @param WC_Vipps_Agreement $agreement
+     * @param $order
+     * @param string $idempotency_key
+     */
+    public function capture_reserved_charge( WC_Vipps_Charge $charge, WC_Vipps_Agreement $agreement, $order, string $idempotency_key ): WC_Vipps_Charge {
+        WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Attempting to capture reserve charge: %s for agreement: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id, $agreement->id ) );
+
+        $this->api->capture_reserved_charge( $agreement, $charge, $idempotency_key );
+
+        // Set the charge status manually as we can safely assume it was charged here. This avoids making another API request.
+        $charge->set_status( WC_Vipps_Charge::STATUS_CHARGED );
+
+        WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Captured reserve charge: %s for agreement: %s', WC_Vipps_Recurring_Helper::get_id( $order ), $charge->id, $agreement->id ) );
+
+        return $charge;
+    }
+
+    /**
+     * @param $order
+     *
+     * @return array
+     */
+    public function get_subscriptions_for_order( $order ): array {
+        return WC_Vipps_Recurring_Helper::get_subscriptions_for_order( $order );
+    }
+
+    private function end_gateway_change_checking( $subscription ) {
+        $subscription->delete_meta_data( WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_WAITING_FOR_GATEWAY_CHANGE );
+        $subscription->delete_meta_data( '_new_agreement_id' );
+        $subscription->delete_meta_data( '_old_agreement_id' );
+    }
+
+    /**
+     * @param $subscription_id
+     *
+     * @throws WC_Vipps_Recurring_Exception
+     */
+    public function maybe_process_gateway_change( $subscription_id ): void {
+        $subscription = wcs_get_subscription( $subscription_id );
+
+        if ( $subscription->meta_exists( '_new_agreement_id' ) ) {
+            $new_agreement_id = WC_Vipps_Recurring_Helper::get_meta( $subscription, '_new_agreement_id' );
+            $agreement        = $this->api->get_agreement( $new_agreement_id );
+
+            if ( $agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE ) {
+                $old_agreement_id = WC_Vipps_Recurring_Helper::get_meta( $subscription, '_old_agreement_id' );
+
+                WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Processing subscription gateway change with new agreement id: %s and old agreement id: %s', WC_Vipps_Recurring_Helper::get_id( $subscription ), $new_agreement_id, $old_agreement_id ) );
+                if ( ! empty( $old_agreement_id ) && $new_agreement_id !== $old_agreement_id ) {
+                    WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Cancelling old agreement id: %s in Vipps/MobilePay due to gateway change', WC_Vipps_Recurring_Helper::get_id( $subscription ), $old_agreement_id ) );
+
+                    $idempotency_key = $this->get_idempotency_key( $subscription );
+                    $this->api->cancel_agreement( $old_agreement_id, $idempotency_key );
+                }
+
+                WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, $new_agreement_id );
+
+                WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Subscription gateway change completed', WC_Vipps_Recurring_Helper::get_id( $subscription ) ) );
+                WC_Subscriptions_Change_Payment_Gateway::update_payment_method( $subscription, $this->id );
+                $this->end_gateway_change_checking( $subscription );
+            }
+
+            if ( in_array( $agreement->status, [ WC_Vipps_Agreement::STATUS_STOPPED, 'EXPIRED' ], true ) ) {
+                $subscription->add_order_note( __( 'Payment gateway change request cancelled in Vipps/MobilePay', 'woo-vipps' ) );
+            }
+
+            if ( in_array( $agreement->status, [
+                WC_Vipps_Agreement::STATUS_STOPPED,
+                WC_Vipps_Agreement::STATUS_EXPIRED
+            ], true ) ) {
+                $this->end_gateway_change_checking( $subscription );
+            }
+
+            $subscription->save();
+        }
+    }
+
+    /**
+     * @param $subscription_id
+     *
+     * @throws WC_Vipps_Recurring_Config_Exception
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     */
+    public function maybe_update_subscription_details_in_app( $subscription_id ): void {
+        $subscription = wcs_get_subscription( $subscription_id );
+
+        $payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $subscription );
+        if ( $payment_method !== $this->id ) {
+            return;
+        }
+
+        $agreement = $this->get_agreement_from_order( $subscription );
+        if ( $agreement !== false && $agreement->status !== WC_Vipps_Agreement::STATUS_ACTIVE ) {
+            WC_Vipps_Recurring_Helper::set_update_in_app_completed( $subscription );
+
+            return;
+        }
+
+        $parent_order = $subscription->get_parent();
+        $items        = array_reverse( $subscription->get_items() );
+
+        // we can only ever have one subscription as long as 'multiple_subscriptions' is disabled
+        $item = array_pop( $items );
+
+        if ( ! $item ) {
+            return;
+        }
+
+        $item_name           = $item->get_name();
+        $parent_product      = wc_get_product( $item->get_product_id() );
+        $product_description = WC_Vipps_Recurring_Helper::get_product_description( $parent_product );
+
+        $agreement_description = null;
+        if ( $prefix = WC_Vipps_Recurring_Helper::get_meta( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX ) ) {
+            $agreement_description = "[$prefix]";
+        }
+
+        if ( $product_description ) {
+            $agreement_description .= " $product_description";
+        }
+
+        $updated_agreement = ( new WC_Vipps_Agreement() )
+            ->set_pricing( ( new WC_Vipps_Agreement_Pricing() )
+                ->set_amount( WC_Vipps_Recurring_Helper::get_vipps_amount( $subscription->get_total() ) ) )
+            ->set_product_name( $item_name );
+
+        if ( $agreement_description ) {
+            $updated_agreement = $updated_agreement->set_product_description( $agreement_description );
+        }
+
+        $agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $subscription );
+        if ( empty( $agreement_id ) ) {
+            $agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $parent_order );
+        }
+
+        if ( $agreement_id ) {
+            try {
+                WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Agreement updated in app for agreement id: %s', $subscription_id, $agreement_id ) );
+
+                $idempotency_key = $this->get_idempotency_key( $subscription );
+                $this->api->update_agreement( $agreement_id, $updated_agreement, $idempotency_key );
+            } catch ( Exception $e ) {
+                // do nothing
+            }
+        }
+
+        WC_Vipps_Recurring_Helper::set_update_in_app_completed( $subscription );
+    }
+
+    /**
+     * @param $order
+     * @param $subscription
+     * @param bool $is_gateway_change
+     *
+     * @return WC_Vipps_Agreement
+     * @throws WC_Vipps_Recurring_Invalid_Value_Exception
+     */
+    public function create_vipps_agreement_from_order( $order, $subscription = null, bool $is_gateway_change = false ): WC_Vipps_Agreement {
+        $order_id = WC_Vipps_Recurring_Helper::get_id( $order );
+
+        if ( ! $subscription ) {
+            $subscription = $order;
+        }
+
+        // This supports not yet having a subscription, purely because of Express and Checkout orders
+        if ( is_a( $subscription, 'WC_Subscription' ) ) {
+            $subscription_period   = $subscription->get_billing_period();
+            $subscription_interval = $subscription->get_billing_interval();
+        } else {
+            $subscription_groups = $this->create_partial_subscription_groups_from_order( $order );
+            $items               = array_pop( $subscription_groups );
+            $product             = $items[0]->get_product();
+
+            $subscription_period   = WC_Subscriptions_Product::get_period( $product );
+            $subscription_interval = WC_Subscriptions_Product::get_interval( $product );
+        }
+
+        $items = array_reverse( $order->get_items() );
+
+        $has_more_products = count( $items ) > 1;
+
+        // we can only ever have one subscription as long as 'multiple_subscriptions' is disabled, so we can fetch the first subscription
+        $subscription_items = array_filter( $items, static function ( $item ) {
+            return apply_filters( 'wc_vipps_recurring_item_is_subscription', WC_Subscriptions_Product::is_subscription( $item['product_id'] ), $item );
+        } );
+
+        $subscription_item = array_pop( $subscription_items );
+        $product           = $subscription_item->get_product();
+        $parent_product    = wc_get_product( $subscription_item->get_product_id() );
+
+        $extra_initial_charge_description = '';
+
+        if ( $has_more_products ) {
+            $other_items = array_filter( $items, static function ( $other_item ) use ( $subscription_item ) {
+                return $subscription_item['product_id'] !== $other_item['product_id'];
+            } );
+
+            foreach ( $other_items as $product_item ) {
+                $extra_initial_charge_description .= WC_Vipps_Recurring_Helper::get_product_description( $product_item->get_product() ) . ', ';
+            }
+
+            $extra_initial_charge_description = rtrim( $extra_initial_charge_description, ', ' );
+        }
+
+        $is_virtual     = $product->is_virtual();
+        $direct_capture = $parent_product->get_meta( WC_Vipps_Recurring_Helper::META_PRODUCT_DIRECT_CAPTURE ) === 'yes';
+
+        $agreement_url = filter_var( get_permalink( get_option( 'woocommerce_myaccount_page_id' ) ), FILTER_VALIDATE_URL )
+            ? get_permalink( get_option( 'woocommerce_myaccount_page_id' ) )
+            : wc_get_account_endpoint_url( 'dashboard' );
+
+        if ( ! filter_var( $agreement_url, FILTER_VALIDATE_URL ) ) {
+            $agreement_url = get_home_url();
+        }
+
+        $redirect_url = WC_Vipps_Recurring_Helper::get_payment_redirect_url( $order, $is_gateway_change );
+
+        // total no longer returns the order amount when gateway is being changed
+        $agreement_total = $subscription->get_total( 'code' );
+
+        // when we're performing a variation switch we need some special logic in Vipps
+        $is_subscription_switch = wcs_order_contains_switch( $order );
+
+        if ( $is_subscription_switch ) {
+            $subscription_switch_data = WC_Vipps_Recurring_Helper::get_meta( $order, '_subscription_switch_data' );
+
+            if ( isset( $subscription_switch_data[ array_key_first( $subscription_switch_data ) ]['switches'] ) ) {
+                $switches    = $subscription_switch_data[ array_key_first( $subscription_switch_data ) ]['switches'];
+                $switch_data = $switches[ array_key_first( $switches ) ];
+                $direction   = $switch_data['switch_direction'];
+
+                if ( $direction === 'upgrade' ) {
+                    $agreement_total += $order->get_total();
+                }
+            }
+        }
+
+        $has_trial           = WC_Subscriptions_Product::get_trial_length( $product ) !== 0;
+        $is_zero_amount      = (int) $order->get_total() === 0 || $is_gateway_change;
+        $capture_immediately = $is_virtual || $direct_capture;
+        $has_synced_product  = WC_Subscriptions_Synchroniser::subscription_contains_synced_product( $subscription );
+
+        $sign_up_fee       = WC_Subscriptions_Order::get_sign_up_fee( $order );
+        $has_campaign      = $has_trial || $has_synced_product || $is_zero_amount || $order->get_total_discount() !== 0.00 || $is_subscription_switch || $sign_up_fee;
+        $has_free_campaign = $is_subscription_switch || $sign_up_fee || $has_synced_product || $has_trial;
+
+        // when Prorate First Renewal is set to "Never (charge the full recurring amount at sign-up)" we don't want to have a campaign
+        // also not when the order total is the same as the agreement total
+        if ( $has_free_campaign && $has_synced_product && $order->get_total() === $agreement_total ) {
+            $has_campaign = false;
+        }
+
+        $agreement = ( new WC_Vipps_Agreement() )
+            ->set_external_id( $order_id )
+            ->set_pricing(
+                ( new WC_Vipps_Agreement_Pricing() )
+                    ->set_type( WC_Vipps_Agreement_Pricing::TYPE_LEGACY )
+                    ->set_currency( $order->get_currency() )
+                    ->set_amount( apply_filters( 'wc_vipps_recurring_agreement_pricing_amount', WC_Vipps_Recurring_Helper::get_vipps_amount( $agreement_total ), $order ) )
+            )
+            ->set_interval(
+                ( new WC_Vipps_Agreement_Interval() )
+                    ->set_unit( strtoupper( $subscription_period ) )
+                    ->set_count( (int) $subscription_interval )
+            )
+            ->set_product_name( $subscription_item->get_name() )
+            ->set_merchant_agreement_url( apply_filters( 'wc_vipps_recurring_merchant_agreement_url', $agreement_url ) )
+            ->set_merchant_redirect_url( apply_filters( 'wc_vipps_recurring_merchant_redirect_url', $redirect_url ) );
+
+        $product_description = WC_Vipps_Recurring_Helper::get_product_description( $product );
+        if ( $product_description ) {
+            $agreement = $agreement->set_product_description( $product_description );
+        }
+
+        // validate phone number and only add it if it's up to Vipps' standard to avoid errors
+        if ( WC_Vipps_Recurring_Helper::is_valid_phone_number( $order->get_billing_phone() ) ) {
+            $agreement = $agreement->set_phone_number( $order->get_billing_phone() );
+        }
+
+        if ( ! $is_zero_amount ) {
+            $initial_charge_description = WC_Vipps_Recurring_Helper::get_product_description( $parent_product );
+            if ( ! empty( $extra_initial_charge_description ) ) {
+                $initial_charge_description .= ' + ' . $extra_initial_charge_description;
+
+                if ( $has_campaign ) {
+                    $initial_charge_description = $extra_initial_charge_description;
+                }
+            }
+
+            $agreement = $agreement->set_initial_charge(
+                ( new WC_Vipps_Agreement_Initial_Charge() )
+                    ->set_amount( apply_filters( 'wc_vipps_recurring_agreement_initial_charge_amount', WC_Vipps_Recurring_Helper::get_vipps_amount( $order->get_total() ), $order ) )
+                    ->set_description( empty( $initial_charge_description ) ? $subscription_item->get_name() : $initial_charge_description )
+                    ->set_transaction_type( $capture_immediately ? WC_Vipps_Agreement_Initial_Charge::TRANSACTION_TYPE_DIRECT_CAPTURE : WC_Vipps_Agreement_Initial_Charge::TRANSACTION_TYPE_RESERVE_CAPTURE )
+            );
+
+            WC_Vipps_Recurring_Helper::update_meta_data( $order, $capture_immediately ? WC_Vipps_Recurring_Helper::META_ORDER_DIRECT_CAPTURE : WC_Vipps_Recurring_Helper::META_ORDER_RESERVED_CAPTURE, true );
+        }
+
+        if ( $has_campaign ) {
+            $campaign_price = $has_free_campaign ? $sign_up_fee : $order->get_total();
+
+            $campaign_type   = WC_Vipps_Agreement_Campaign::TYPE_PRICE_CAMPAIGN;
+            $campaign_period = null;
+
+            if ( $has_trial ) {
+                $campaign_type     = WC_Vipps_Agreement_Campaign::TYPE_PERIOD_CAMPAIGN;
+                $campaign_end_date = null;
+                $campaign_period   = ( new WC_Vipps_Agreement_Campaign_Period() )
+                    ->set_count( WC_Subscriptions_Product::get_trial_length( $product ) )
+                    ->set_unit( strtoupper( WC_Subscriptions_Product::get_trial_period( $product ) ) );
+            } else {
+                $next_payment = WC_Subscriptions_Product::get_first_renewal_payment_date( $product );
+                $end_date     = WC_Subscriptions_Product::get_expiration_date( $product );
+
+                $campaign_end_date = $end_date === 0 ? $next_payment : $end_date;
+            }
+
+            $agreement = $agreement->set_campaign(
+                ( new WC_Vipps_Agreement_Campaign() )
+                    ->set_type( $campaign_type )
+                    ->set_price( WC_Vipps_Recurring_Helper::get_vipps_amount( $campaign_price ) )
+                    ->set_end( $campaign_end_date )
+                    ->set_period( $campaign_period )
+            );
+        }
+
+        $order->save();
+
+        return apply_filters( 'wc_vipps_recurring_process_payment_agreement', $agreement, $subscription, $order );
+    }
+
+    /**
+     * Process a payment when checking out in WooCommerce
+     *
+     * https://docs.woocommerce.com/document/subscriptions/develop/payment-gateway-integration/
+     * "Putting it all Together"
+     *
+     * @param int $order_id
+     *
+     * @throws Exception
+     */
+    public function process_payment( $order_id, bool $retry = true, bool $previous_error = false ): array {
+        $is_gateway_change = wcs_is_subscription( $order_id );
+
+        $subscription = null;
+
+        $order     = wc_get_order( $order_id );
+        $debug_msg = sprintf( '[%s] process_payment (gateway change: %s)', $order_id, $is_gateway_change ? 'Yes' : 'No' ) . "\n";
+
+        $is_failed_renewal_order = wcs_cart_contains_failed_renewal_order_payment() !== false;
+
+        if ( ! $is_gateway_change
+             && ! $is_failed_renewal_order
+             && ! wcs_order_contains_subscription( $order )
+             && ! wcs_order_contains_early_renewal( $order ) ) {
+            return [
+                'result'   => 'fail',
+                'redirect' => ''
+            ];
+        }
+
+        // If we have an early renewal order on our hands we should
+        if ( wcs_order_contains_early_renewal( $order ) ) {
+            $renewal_order = $order;
+
+            $subscriptions = wcs_get_subscriptions_for_renewal_order( $renewal_order );
+            $subscription  = $subscriptions[ array_key_first( $subscriptions ) ];
+
+            $agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $subscription );
+            if ( $agreement_id ) {
+                $existing_agreement = $this->api->get_agreement( $agreement_id );
+
+                if ( $existing_agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE ) {
+                    WC_Subscriptions_Payment_Gateways::trigger_gateway_renewal_payment_hook( $renewal_order );
+
+                    // Trigger the subscription payment complete hooks and reset suspension counts and user roles.
+                    $subscription->payment_complete();
+
+                    wcs_update_dates_after_early_renewal( $subscription, $renewal_order );
+                    wc_add_notice( __( 'Your early renewal order was successful.', 'woocommerce-subscriptions' ) );
+
+                    $renewal_order = wc_get_order( $renewal_order->get_id() );
+
+                    return [
+                        'result'   => 'success',
+                        'redirect' => $renewal_order->get_view_order_url()
+                    ];
+                }
+            }
+
+            // We need to update the gateway to Vipps/MobilePay after the payment is completed if an agreement is active
+            WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_RENEWING_WITH_VIPPS, true );
+            $subscription->save();
+        }
+
+        try {
+            if ( ! $subscription ) {
+                $subscription = $order;
+            }
+
+            if ( ! $is_gateway_change ) {
+                $subscriptions = $this->get_subscriptions_for_order( $order );
+
+                // we can only ever have one subscription as long as 'multiple_subscriptions' is disabled
+                $subscription = $subscriptions[ array_key_first( $subscriptions ) ];
+            }
+
+            /*
+             * if this order has a PENDING or ACTIVE agreement in Vipps/MobilePay we should not allow checkout anymore
+             * this will prevent duplicate transactions
+             */
+            $agreement_id              = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
+            $already_swapping_to_vipps = WC_Vipps_Recurring_Helper::get_meta( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_WAITING_FOR_GATEWAY_CHANGE );
+
+            if ( $agreement_id && ( ! $is_gateway_change || $already_swapping_to_vipps ) && ! $is_failed_renewal_order ) {
+                if ( ! $already_swapping_to_vipps ) {
+                    $existing_agreement = $this->get_agreement_from_order( $order );
+                } else {
+                    $new_agreement_id   = WC_Vipps_Recurring_Helper::get_meta( $subscription, '_new_agreement_id' );
+                    $existing_agreement = $this->api->get_agreement( $new_agreement_id );
+                }
+
+                if ( $existing_agreement->status === WC_Vipps_Agreement::STATUS_ACTIVE ) {
+                    throw new WC_Vipps_Recurring_Temporary_Exception( __( 'This subscription is already active in Vipps/MobilePay. You can leave this page.', 'woo-vipps' ) );
+                }
+            }
+
+            $items = array_reverse( $order->get_items() );
+
+            /*
+             * WooCommerce Subscriptions should really deal with this themselves, but when other gateways with support for `multiple_subscriptions`
+             * are enabled WooCommerce Subscriptions allows this scenario for our plugin too. This is not ideal so let's deny it here.
+             * There's no good way to make this obvious to a customer in the app, especially if the products have different durations
+             * i.e. one yearly and one monthly
+             */
+            $has_more_products = count( $items ) > 1;
+            if ( $has_more_products ) {
+                $counter = 1;
+
+                foreach ( $items as $item ) {
+                    if ( ! WC_Subscriptions_Product::is_subscription( $item['product_id'] ) ) {
+                        continue;
+                    }
+
+                    if ( $counter > 1 ) {
+                        // translators: %s: brand (Vipps or MobilePay)
+                        wc_add_notice( sprintf( __( 'Different subscription products can not be purchased at the same time using %s.', 'woo-vipps' ), $this->title ), 'error' );
+
+                        return [
+                            'result'   => 'fail',
+                            'redirect' => ''
+                        ];
+                    }
+
+                    $counter ++;
+                }
+            }
+
+            $agreement = $this->create_vipps_agreement_from_order( $order, $subscription, $is_gateway_change );
+
+            $idempotency_key = $this->get_idempotency_key( $order );
+            if ( $is_gateway_change ) {
+                $idempotency_key = $this->api->generate_idempotency_key();
+            }
+
+            $response = $this->api->create_agreement( $agreement, $idempotency_key );
+
+            $is_subscription_switch = wcs_order_contains_switch( $order );
+            $is_zero_amount         = (int) $order->get_total() === 0 || $is_gateway_change;
+
+            // mark the old agreement for cancellation to leave no dangling agreements in Vipps
+            $should_cancel_old = $is_gateway_change || $is_subscription_switch || $is_failed_renewal_order;
+            if ( $should_cancel_old ) {
+                if ( $is_gateway_change ) {
+                    /* translators: Vipps/MobilePay Agreement ID */
+                    $message = sprintf( __( 'Request to change gateway to Vipps/MobilePay with agreement ID: %s.', 'woo-vipps' ), $response['agreementId'] );
+                    $subscription->add_order_note( $message );
+                    $debug_msg .= 'Request to change gateway to Vipps' . "\n";
+                } elseif ( $is_subscription_switch ) {
+                    $debug_msg .= 'Request to switch subscription variation' . "\n";
+                } else {
+                    $debug_msg .= 'Request to pay for a failed renewal order' . "\n";
+                }
+
+                WC_Vipps_Recurring_Helper::update_meta_data( $subscription, '_old_agreement_id', WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $subscription ) );
+                WC_Vipps_Recurring_Helper::update_meta_data( $subscription, '_new_agreement_id', $response['agreementId'] );
+                WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_WAITING_FOR_GATEWAY_CHANGE, true );
+            }
+
+            if ( ! $is_gateway_change ) {
+                if ( ! $should_cancel_old ) {
+                    WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, $response['agreementId'] );
+                }
+
+                if ( $is_zero_amount ) {
+                    WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_ZERO_AMOUNT, true );
+                }
+
+                WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, $response['agreementId'] );
+                WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, true );
+
+                /* translators: Vipps/MobilePay Agreement ID */
+                $message = sprintf( __( 'Agreement created: %s. Customer sent to Vipps/MobilePay for confirmation.', 'woo-vipps' ), $response['agreementId'] );
+                $order->add_order_note( $message );
+            }
+
+            $debug_msg .= sprintf( 'Created agreement with agreement ID: %s', $response['agreementId'] ) . "\n";
+
+            if ( isset( $response['chargeId'] ) ) {
+                WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $response['chargeId'] );
+            }
+
+            WC_Vipps_Recurring_Helper::delete_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_IS_CHECKOUT );
+            WC_Vipps_Recurring_Helper::delete_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS );
+            WC_Vipps_Recurring_Helper::delete_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_ORDER_IS_CHECKOUT );
+            WC_Vipps_Recurring_Helper::delete_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS );
+
+            // save meta
+            $order->save();
+            $subscription->save();
+
+            $debug_msg .= sprintf( 'Debug body: %s', json_encode( $agreement->to_array() ) ) . "\n";
+            $debug_msg .= sprintf( 'Debug response: %s', json_encode( array_merge( $response, [ 'vippsConfirmationUrl' => 'redacted' ] ) ) );
+            WC_Vipps_Recurring_Logger::log( $debug_msg );
+
+            return [
+                'result'   => 'success',
+                'redirect' => $response['vippsConfirmationUrl'],
+            ];
+        } catch ( WC_Vipps_Recurring_Temporary_Exception $e ) {
+            wc_add_notice( $e->getMessage(), 'error' );
+
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Temporary error in process_payment: %s', $order_id, $e->getMessage() ) );
+
+            return [
+                'result'   => 'fail',
+                'redirect' => '',
+            ];
+        } catch ( WC_Vipps_Recurring_Exception $e ) {
+            wc_add_notice( $e->getLocalizedMessage(), 'error' );
+
+            $order->update_status( 'failed' );
+
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Error in process_payment: %s', $order_id, $e->getMessage() ) );
+
+            return [
+                'result'   => 'fail',
+                'redirect' => '',
+            ];
+        }
+    }
+
+    /**
+     * All payment icons that work with Vipps. Some icons references
+     * WC core icons.
+     *
+     * @return array
+     * @since 4.1.0 Changed to using img with svg (colored) instead of fonts.
+     * @since 4.0.0
+     */
+    public function payment_icons(): array {
+        return apply_filters(
+            'wc_vipps_recurring_payment_icons',
+            [
+                'vippsmobilepay' => '<img src="' . WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/images/' . $this->brand . '-mark.svg" class="vipps-recurring-icon" alt="' . $this->title . '" />',
+            ]
+        );
+    }
+
+    /**
+     * Get_icon function.
+     *
+     * @return string
+     * @version 4.0.0
+     * @since 1.0.0
+     */
+    public function get_icon(): string {
+        $icons = $this->payment_icons();
+
+        return apply_filters( 'woocommerce_gateway_icon', $icons['vippsmobilepay'], $this->id );
+    }
+
+    /**
+     * @param $key
+     * @param $data
+     *
+     * @return false|string
+     */
+    public function generate_page_dropdown_html( $key, $data ) {
+        $field_key = $this->get_field_key( $key );
+        $defaults  = [
+            'title'            => '',
+            'class'            => '',
+            'type'             => 'page_dropdown',
+            'desc_tip'         => false,
+            'description'      => '',
+            'show_option_none' => ''
+        ];
+
+        $data = wp_parse_args( $data, $defaults );
+
+        $dropdown_pages = wp_dropdown_pages( [
+            'echo'             => 0,
+            'show_option_none' => $data['show_option_none'],
+            'selected'         => $this->get_option( $key ),
+            'id'               => $field_key,
+            'name'             => $field_key,
+            'class'            => $data['class']
+        ] );
+
+        ob_start();
+        ?>
         <tr valign="top">
             <th
                     scope="row"
@@ -1797,1135 +1797,1135 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
                 <fieldset>
                     <legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span>
                     </legend>
-					<?php echo $dropdown_pages; ?>
-					<?php echo $this->get_description_html( $data ); // WPCS: XSS ok. ?>
+                    <?php echo $dropdown_pages; ?>
+                    <?php echo $this->get_description_html( $data ); // WPCS: XSS ok. ?>
                 </fieldset>
             </td>
         </tr>
-		<?php
-
-		return ob_get_clean();
-	}
-
-	/**
-	 * Initialise Gateway Settings Form Fields
-	 */
-	public function init_form_fields(): void {
-		$this->form_fields = require( __DIR__ . '/admin/vipps-recurring-settings.php' );
-
-		// Set some options and default values
-		$this->form_fields['brand']['default'] = $this->detect_default_brand();
-
-		$this->form_fields['order_prefix']['default'] = WC_Vipps_Recurring::get_instance()->generate_order_prefix();
-
-		if ( $this->get_option( 'test_mode' ) === "yes" || WC_VIPPS_RECURRING_TEST_MODE ) {
-			$this->form_fields['title_test_api'] = [
-				'type'  => 'title',
-				'title' => __( 'Test API settings', 'woo-vipps' ),
-			];
-
-			$this->form_fields['test_merchant_serial_number'] = $this->form_fields['merchant_serial_number'];
-			$this->form_fields['test_client_id']              = $this->form_fields['client_id'];
-			$this->form_fields['test_secret_key']             = $this->form_fields['secret_key'];
-			$this->form_fields['test_subscription_key']       = $this->form_fields['subscription_key'];
-		}
-	}
-
-	function validate_text_field( $key, $value ) {
-		if ( $key !== 'order_prefix' ) {
-			return parent::validate_text_field( $key, $value );
-		}
-
-		return preg_replace( '![^a-zA-Z0-9\-]!', '', $value );
-	}
-
-	public function detect_default_brand(): string {
-		$locale         = get_locale();
-		$store_location = wc_get_base_location();
-		$store_country  = $store_location['country'] ?? '';
-		$currency       = get_woocommerce_currency();
-
-		$default_brand = "mobilepay";
-
-		// If store location, locale, or currency is Norwegian, use Vipps
-		if ( $store_country == "NO" || preg_match( "/_NO/", $locale ) || $currency == "NOK" ) {
-			$default_brand = "vipps";
-		}
-
-		return $default_brand;
-	}
-
-	/**
-	 * @param $what
-	 */
-	private function admin_error( $what ): void {
-		add_action( 'admin_notices', static function () use ( $what ) {
-			echo "<div class='notice notice-error is-dismissible'><p>$what</p></div>";
-		} );
-	}
-
-	/**
-	 * @param $what
-	 */
-	private function admin_notify( $what, $type = "info" ): void {
-		add_action( 'admin_notices', static function () use ( $what, $type ) {
-			echo "<div class='notice notice-$type is-dismissible'><p>$what</p></div>";
-		} );
-	}
-
-	public function process_admin_options(): bool {
-		$saved = parent::process_admin_options();
-		delete_transient( '_vipps_keyset' ); // Same transient as for the payment api IOK 2024-12-03
-
-		$this->init_form_fields();
-
-		if ( $this->get_option( 'enabled' ) === "yes" ) {
-			$this->webhook_initialize();
-
-			try {
-				$this->api->get_access_token( true );
-				update_option( WC_Vipps_Recurring_Helper::OPTION_CONFIGURED, 1, true );
-
-				$this->admin_notify( __( 'Successfully authenticated with the Vipps/MobilePay API', 'woo-vipps' ) );
-			} catch ( Exception $e ) {
-				update_option( WC_Vipps_Recurring_Helper::OPTION_CONFIGURED, 0, true );
-
-				/* translators: %s: the error message returned from Vipps/MobilePay */
-				$this->admin_error( sprintf( __( 'Could not authenticate with the Vipps/MobilePay API: %s', 'woo-vipps' ), $e->getMessage() ) );
-			}
-		}
-
-		$checkout_enabled = $this->get_option( 'checkout_enabled' ) === "yes";
-		$test_mode        = $this->get_option( 'test_mode' ) === "yes" || WC_VIPPS_RECURRING_TEST_MODE;
-
-		// Validate that we have an MSN set, as it is required in Checkout.
-		$merchant_serial_number = $test_mode ? $this->get_option( 'test_merchant_serial_number' ) : $this->get_option( 'merchant_serial_number' );
-		if ( empty( $merchant_serial_number ) ) {
-			$this->admin_notify( __( 'You need to provide a Merchant Serial Number before you can enable Checkout.', 'woo-vipps' ), "error" );
-
-			// Disable checkout if we do not have an MSN value.
-			$this->update_option( 'checkout_enabled', 'no' );
-			update_option( WC_Vipps_Recurring_Helper::OPTION_CHECKOUT_ENABLED, false, true );
-
-			return $saved;
-		}
-
-		update_option( WC_Vipps_Recurring_Helper::OPTION_CHECKOUT_ENABLED, $checkout_enabled, true );
-
-		if ( $checkout_enabled ) {
-			WC_Vipps_Recurring::get_instance()->maybe_create_checkout_page();
-		}
-
-		return $saved;
-	}
-
-	/**
-	 * @param $statuses
-	 *
-	 * @return array
-	 */
-	public function append_valid_statuses_for_payment_complete( $statuses ): array {
-		$statuses = array_merge( $statuses, $this->statuses_to_attempt_capture );
-
-		if ( $this->transition_renewals_to_completed && ! in_array( 'completed', $statuses, true ) ) {
-			$statuses[] = 'completed';
-		}
-
-		return $statuses;
-	}
-
-	/**
-	 * @param $payment_meta
-	 * @param $subscription
-	 *
-	 * @return mixed
-	 */
-	public function add_subscription_payment_meta( $payment_meta, $subscription ) {
-		$payment_meta[ $this->id ] = [
-			'post_meta' => [
-				'_agreement_id' => [
-					'value' => WC_Vipps_Recurring_Helper::get_meta( $subscription, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID ),
-					'label' => __( 'Vipps/MobilePay Agreement ID', 'woo-vipps' ),
-				]
-			],
-		];
-
-		return $payment_meta;
-	}
-
-	/**
-	 * @param $payment_method_id
-	 * @param $payment_meta
-	 *
-	 * @throws Exception
-	 */
-	public function validate_subscription_payment_meta( $payment_method_id, $payment_meta ): void {
-		if ( $this->id !== $payment_method_id ) {
-			return;
-		}
-
-		$agreement_id = $payment_meta['post_meta']['_agreement_id']['value'];
-
-		try {
-			$this->api->get_agreement( $agreement_id );
-		} catch ( Exception $e ) {
-			throw new \RuntimeException( __( 'This Vipps/MobilePay agreement ID is invalid.', 'woo-vipps' ) );
-		}
-	}
-
-	public function cart_needs_payment( $needs_payment, $cart ) {
-		$cart_switch_items = wcs_cart_contains_switches();
-
-		if ( false === $needs_payment && 0 == $cart->total && false !== $cart_switch_items && ! wcs_is_manual_renewal_required() ) {
-			foreach ( $cart_switch_items as $cart_switch_details ) {
-				$subscription = wcs_get_subscription( $cart_switch_details['subscription_id'] );
-
-				if ( $this->id === $subscription->get_payment_method() ) {
-					$needs_payment = true;
-					break;
-				}
-			}
-		}
-
-		return $needs_payment;
-	}
-
-	/**
-	 * @param $subscription
-	 */
-	public function handle_subscription_switch_completed( $subscription ): void {
-		$payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $subscription );
-		if ( $this->id !== $payment_method ) {
-			return;
-		}
-
-		WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Subscription switch completed", WC_Vipps_Recurring_Helper::get_id( $subscription ) ) );
-
-		WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX );
-		$subscription->save();
-
-		try {
-			$this->maybe_update_subscription_details_in_app( WC_Vipps_Recurring_Helper::get_id( $subscription ) );
-		} catch ( Exception $exception ) {
-			// do nothing, we don't want to throw an error in the user's face
-		}
-	}
-
-	/**
-	 * @param WC_Subscription $subscription
-	 * @param $new_status
-	 * @param $old_status
-	 */
-	public function maybe_handle_subscription_status_transitions( WC_Subscription $subscription, $new_status, $old_status ): void {
-		$payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $subscription );
-
-		/*
-		 * note: if we reverse the if statement to reduce nesting I fear we may run into an early stop of code execution issue
-		 */
-		if ( $this->id === $payment_method ) {
-			$order = wc_get_order( WC_Vipps_Recurring_Helper::get_id( $subscription ) );
-
-			if ( $new_status === 'pending-cancel' ) {
-				WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
-				WC_Vipps_Recurring_Helper::update_meta_data(
-					$order,
-					WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX,
-					__( 'Pending cancellation', 'woo-vipps' )
-				);
-
-				$order->save();
-			}
-
-			if ( $new_status === 'cancelled' ) {
-				WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
-				WC_Vipps_Recurring_Helper::update_meta_data(
-					$order,
-					WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX,
-					__( 'Cancelled', 'woo-vipps' )
-				);
-
-				$order->save();
-			}
-
-			if ( $new_status === 'on-hold' ) {
-				WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
-				WC_Vipps_Recurring_Helper::update_meta_data(
-					$order,
-					WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX,
-					__( 'On hold', 'woo-vipps' )
-				);
-
-				$order->save();
-			}
-
-			if ( ( $old_status === 'pending-cancel' || $old_status === 'on-hold' ) && $new_status !== 'cancelled' ) {
-				WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
-				$order->delete_meta_data( WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX );
-
-				$order->save();
-			}
-		}
-	}
-
-	/**
-	 * Don't transfer Vipps/MobilePay idempotency key or any other keys unique to a charge or order to resubscribe orders.
-	 *
-	 * @param mixed $resubscribe_order The order created for the customer to resubscribe to the old expired/cancelled subscription
-	 */
-	public function delete_resubscribe_meta( $resubscribe_order ): void {
-		WC_Vipps_Recurring_Helper::delete_meta_data( $resubscribe_order, WC_Vipps_Recurring_Helper::META_CHARGE_ID );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $resubscribe_order, WC_Vipps_Recurring_Helper::META_CHARGE_CAPTURED );
-
-		WC_Vipps_Recurring_Helper::delete_meta_data( $resubscribe_order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $resubscribe_order, WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $resubscribe_order, WC_Vipps_Recurring_Helper::META_ORDER_EXPRESS_AUTH_TOKEN );
-
-		$this->delete_renewal_meta( $resubscribe_order );
-	}
-
-	/**
-	 * Don't transfer Vipps/MobilePay idempotency key or any other keys unique to a charge or order to renewal orders.
-	 *
-	 * @param mixed $renewal_order The renewal order
-	 */
-	public function delete_renewal_meta( WC_Order $renewal_order ) {
-		// Do not delete the idempotency key if the order has failed previously
-		$has_failed_previously = WC_Vipps_Recurring_Helper::get_meta( $renewal_order, '_failed_renewal_order' );
-		if ( $has_failed_previously !== "yes" ) {
-			WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_ORDER_IDEMPOTENCY_KEY );
-		}
-
-		WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_FAILED );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_FAILED_DESCRIPTION );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_FAILED_REASON );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_LATEST_STATUS );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_CAPTURED );
-
-		WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS );
-		WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_ORDER_EXPRESS_AUTH_TOKEN );
-
-		$renewal_order->save();
-
-		return $renewal_order;
-	}
-
-	/**
-	 * @param $order_id
-	 */
-	public function maybe_cancel_due_charge( $order_id ): void {
-		$order = wc_get_order( $order_id );
-
-		$payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $order );
-		if ( $this->id !== $payment_method ) {
-			return;
-		}
-
-		$agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
-		$charge_id    = WC_Vipps_Recurring_Helper::get_charge_id_from_order( $order );
-
-		if ( $agreement_id === null || $charge_id === null ) {
-			WC_Vipps_Recurring_Helper::delete_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING );
-
-			return;
-		}
-
-		$pending_charge = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING );
-
-		if ( $pending_charge ) {
-			try {
-				if ( get_transient( 'maybe_cancel_due_charge_lock' . $order_id ) ) {
-					return;
-				}
-
-				set_transient( 'maybe_cancel_due_charge_lock' . $order_id, uniqid( '', true ), 30 );
-
-				$charge = $this->api->get_charge( $agreement_id, $charge_id );
-				if ( in_array( $charge->status, [
-					WC_Vipps_Charge::STATUS_DUE,
-					WC_Vipps_Charge::STATUS_PENDING
-				], true ) ) {
-					$idempotency_key = $this->get_idempotency_key( $order );
-					$this->api->cancel_charge( $agreement_id, $charge_id, $idempotency_key );
-					$order->add_order_note( __( 'Cancelled due charge in Vipps/MobilePay.', 'woo-vipps' ) );
-					WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Cancelled DUE charge with ID: %s for agreement with ID: %s', $order_id, $charge_id, $agreement_id ) );
-				}
-			} catch ( Exception $e ) {
-				$order->add_order_note( __( 'Could not cancel charge in Vipps/MobilePay. Please manually check the status of this order if you plan to process a new renewal order!', 'woo-vipps' ) );
-				WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Failed cancelling DUE charge with ID: %s for agreement with ID: %s. Error: %s', $order_id, $charge_id, $agreement_id, $e->getMessage() ) );
-			}
-		}
-	}
-
-	/**
-	 * When renewing early from a different gateway WooCommerce does not update the gateway for you.
-	 * If we detect that you've renewed early with Vipps/MobilePay and the gateway is not set to Vipps/MobilePay we will
-	 * update the gateway for you.
-	 *
-	 * @param $order_id
-	 *
-	 * @return void
-	 * @throws WC_Vipps_Recurring_Exception
-	 */
-	public function after_renew_early_from_another_gateway( $order_id ): void {
-		if ( ! wcs_order_contains_early_renewal( $order_id ) ) {
-			return;
-		}
-
-		$subscriptions = $this->get_subscriptions_for_order( $order_id );
-
-		foreach ( $subscriptions as $subscription ) {
-			if ( $subscription->get_payment_method() === $this->id ) {
-				continue;
-			}
-
-			if ( ! WC_Vipps_Recurring_Helper::get_meta( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_RENEWING_WITH_VIPPS ) ) {
-				continue;
-			}
-
-			$agreement = $this->get_agreement_from_order( $subscription );
-			if ( ! $agreement || $agreement->status !== WC_Vipps_Agreement::STATUS_ACTIVE ) {
-				continue;
-			}
-
-			$subscription->set_payment_method( $this->id );
-			WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_RENEWING_WITH_VIPPS, false );
-			$subscription->save();
-		}
-	}
-
-	/**
-	 * Prevent an order from being transitioned to "processing" when the status is already "completed"
-	 *
-	 * @param $status
-	 * @param $order_id
-	 * @param $order
-	 *
-	 * @return string|null
-	 */
-	public function prevent_backwards_transition_on_completed_order( $status, $order_id, $order ): ?string {
-		if ( $status === 'processing'
-		     && $order->has_status( 'completed' )
-		     && $order->get_payment_method() === $this->id ) {
-			return 'completed';
-		}
-
-		return $status;
-	}
-
-	public function update_agreement_price_in_app( $and_taxes, $subscription ) {
-		if ( ! wcs_is_subscription( $subscription ) ) {
-			return;
-		}
-
-		$payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $subscription );
-		if ( $this->id !== $payment_method ) {
-			return;
-		}
-
-		WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Totals were recalculated. Marking subscription for update in the Vipps/MobilePay app.', WC_Vipps_Recurring_Helper::get_id( $subscription ) ) );
-		WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
-		$subscription->save();
-	}
-
-	/**
-	 * Initialize webhooks if we don't already have one
-	 *
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 */
-	private function webhook_initialize_initial() {
-		$msn = $this->merchant_serial_number;
-
-		// We cannot use webhooks without the MSN being set.
-		if ( empty( $msn ) ) {
-			return;
-		}
-
-		$webhooks       = $this->api->get_webhooks();
-		$local_webhooks = $this->webhook_get_local();
-		$callback_url   = $this->webhook_callback_url();
-
-		// Delete webhooks that are not for our MSN + hostname combination. This prevents us from conflicting with Pay with WooCommerce for Vipps and MobilePay
-		$deletion_tracker = [];
-
-		$webhook_initialized = false;
-
-		foreach ( $webhooks['webhooks'] as $webhook ) {
-			if ( ! isset( $local_webhooks[ $msn ][ $webhook['id'] ] ) ) {
-				// this webhook is not created by us, so we can continue
-				continue;
-			}
-
-			// If we have multiple webhooks for our MSN we can delete the other ones. We do not want duplicates.
-			if ( $webhook_initialized ) {
-				$deletion_tracker[] = $webhook['id'];
-			}
-
-			$webhook_initialized = true;
-		}
-
-		// Create webhook and save it to WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS
-		if ( ! $webhook_initialized ) {
-			$response = $this->api->register_webhook();
-
-			$local_webhooks[ $msn ][ $response['id'] ] = [
-				'secret' => $response['secret'],
-				'url'    => $callback_url
-			];
-		}
-
-		// Delete superfluous webhooks
-		if ( ! empty( $deletion_tracker ) ) {
-			foreach ( $deletion_tracker as $id ) {
-				try {
-					$this->api->delete_webhook( $id );
-					unset( $local_webhooks[ $msn ][ $id ] );
-				} catch ( Exception $e ) {
-					WC_Vipps_Recurring_Logger::log( sprintf( 'Failed to delete webhook %s. Error: %s', $id, $e->getMessage() ) );
-				}
-			}
-		}
-
-		update_option( WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS, $local_webhooks );
-	}
-
-	/**
-	 * Check that our local webhooks point to this site.
-	 * If they don't we should delete them, otherwise we end up with hitting the limit of 5.
-	 *
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 */
-	public function webhook_ensure_this_site(): bool {
-		$msn = $this->merchant_serial_number;
-
-		// We cannot use webhooks without the MSN being set.
-		if ( empty( $msn ) ) {
-			return false;
-		}
-
-		$local_webhooks    = $this->webhook_get_local();
-		$callback_url      = $this->webhook_callback_url();
-		$callback_url_base = strtok( $callback_url, "?" );
-
-		// Make sure we don't do this more than once every 30 minutes, and only if the callback url base changes.
-		$webhook_transient = "vipps-recurring-webhooks-site";
-		if ( get_transient( $webhook_transient ) === $callback_url_base ) {
-			return true;
-		}
-
-		set_transient( $webhook_transient, $callback_url_base, 1800 );
-
-		if ( empty( $local_webhooks[ $msn ] ) ) {
-			return false;
-		}
-
-		$remote_webhooks = $this->api->get_webhooks();
-
-		$ok = true;
-		foreach ( $local_webhooks[ $msn ] as $webhook_id => $webhook ) {
-			$webhook_base_url = strtok( $webhook['url'], "?" );
-
-			if ( $webhook_base_url === $callback_url_base ) {
-				continue;
-			}
-
-			// Check that this webhookId indeed exists in $remote_webhooks before we attempt to delete it
-			$webhook_exists = ! empty( array_filter( $remote_webhooks['webhooks'], function ( $remote_webhook ) use ( $webhook_id ) {
-				return $remote_webhook['id'] === $webhook_id;
-			} ) );
-
-			if ( $webhook_exists ) {
-				$this->api->delete_webhook( $webhook_id );
-			}
-
-			unset( $local_webhooks[ $msn ][ $webhook_id ] );
-
-			$ok = false;
-		}
-
-		update_option( WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS, $local_webhooks );
-
-		return $ok;
-	}
-
-	/**
-	 * Delete all webhooks during uninstall for this MSN
-	 *
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 */
-	public function webhook_teardown() {
-		$msn = $this->merchant_serial_number;
-
-		if ( empty( $msn ) ) {
-			return;
-		}
-
-		$local_webhooks = $this->webhook_get_local();
-
-		if ( empty( $local_webhooks[ $msn ] ) ) {
-			return;
-		}
-
-		$remote_webhooks = $this->api->get_webhooks();
-
-		// We can have multiple MSNs, hence the nested loop
-		foreach ( $local_webhooks as $webhooks ) {
-			foreach ( $webhooks as $webhook_id => $webhook ) {
-				// Check that this webhookId indeed exists in $remote_webhooks before we attempt to delete it
-				$webhook_exists = ! empty( array_filter( $remote_webhooks['webhooks'], function ( $remote_webhook ) use ( $webhook_id ) {
-					return $remote_webhook['id'] === $webhook_id;
-				} ) );
-
-				if ( ! $webhook_exists ) {
-					continue;
-				}
-
-				$this->api->delete_webhook( $webhook_id );
-			}
-		}
-
-		delete_option( WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS );
-	}
-
-	public function webhook_get_local(): array {
-		return get_option( WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS, [ $this->merchant_serial_number => [] ] );
-	}
-
-	public function webhook_initialize() {
-		try {
-			$this->webhook_ensure_this_site();
-			$this->webhook_initialize_initial();
-		} catch ( Exception $e ) {
-			WC_Vipps_Recurring_Logger::log( sprintf( 'Failed to initialize webhooks. Error: %s', $e->getMessage() ) );
-		}
-	}
-
-	public function webhook_callback_url(): string {
-		$base_url = home_url( '/', 'https' );
-
-		$args   = [ 'callback' => 'webhook' ];
-		$action = 'wc_gateway_vipps_recurring';
-
-		if ( ! get_option( 'permalink_structure' ) ) {
-			$args['wc-api'] = $action;
-		} else {
-			$base_url = trailingslashit( home_url( "wc-api/$action", 'https' ) );
-		}
-
-		return add_query_arg( $args, $base_url );
-	}
-
-	private function maybe_get_subscription_from_agreement_webhook( array $webhook_data ) {
-		$order_id = $webhook_data['agreementExternalId'];
-
-		// Check if agreementExternalId is not set, we can get the subscription from agreementId
-		if ( empty( $order_id ) && isset( $webhook_data['agreementId'] ) ) {
-			$agreement_id = $webhook_data['agreementId'];
-
-			$subscriptions = wcs_get_subscriptions( [
-				'subscriptions_per_page' => 1,
-				'subscription_status'    => [ 'active', 'pending', 'on-hold' ],
-				'meta_query'             => [
-					[
-						'key'     => WC_Vipps_Recurring_Helper::META_AGREEMENT_ID,
-						'compare' => '=',
-						'value'   => $agreement_id
-					]
-				]
-			] );
-
-			if ( ! empty( $subscriptions ) ) {
-				return array_pop( $subscriptions );
-			}
-		}
-
-		// If the order id is not a subscription, we can get the subscription from the order
-		if ( ! empty( $order_id ) && ! wcs_is_subscription( $order_id ) ) {
-			$order         = wc_get_order( $order_id );
-			$subscriptions = wcs_get_subscriptions_for_order( $order );
-
-			if ( ! empty( $subscriptions ) ) {
-				return array_pop( $subscriptions );
-			}
-		}
-
-		// Otherwise the order_id is either empty, or a subscription
-		return $order_id;
-	}
-
-	/**
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 */
-	public function handle_webhook_callback( array $webhook_data ): void {
-		WC_Vipps_Recurring_Logger::log( sprintf( "Handling webhook with data: %s", json_encode( $webhook_data ) ) );
-
-		$event_type = $webhook_data['eventType'];
-
-		if ( in_array( $event_type, [
-			'recurring.charge-reserved.v1',
-			'recurring.charge-captured.v1',
-			'recurring.charge-canceled.v1',
-			'recurring.charge-failed.v1',
-		] ) ) {
-			$order_id = $webhook_data['chargeExternalId'];
-
-			if ( empty( $order_id ) ) {
-				$charge_id = $webhook_data['chargeId'];
-
-				$orders = wc_get_orders( [
-					'limit'          => 1,
-					'meta_query'     => [
-						[
-							'key'     => WC_Vipps_Recurring_Helper::META_CHARGE_ID,
-							'compare' => '=',
-							'value'   => $charge_id
-						]
-					],
-					'payment_method' => $this->id,
-					'order_by'       => 'post_date'
-				] );
-
-				$order = array_pop( $orders );
-
-				if ( $order ) {
-					$order_id = WC_Vipps_Recurring_Helper::get_id( $order );
-				}
-			}
-
-			if ( empty( $charge_id ) ) {
-				return;
-			}
-
-			$this->check_charge_status( $order_id );
-		}
-
-		// Customers can now cancel their agreements directly from the app.
-		if ( $event_type === 'recurring.agreement-stopped.v1' ) {
-			// If the initiator of this webhook is ourselves, we must discard it.
-			// Otherwise, we risk cancelling payment gateway changes etc.
-			if ( $webhook_data['actor'] === 'MERCHANT' ) {
-				return;
-			}
-
-			$subscription_id = $this->maybe_get_subscription_from_agreement_webhook( $webhook_data );
-			if ( empty( $subscription_id ) ) {
-				return;
-			}
-
-			$subscription = wcs_get_subscription( $subscription_id );
-
-			if ( empty( $subscription ) ) {
-				return;
-			}
-
-			$message = __( 'Subscription cancelled by the customer via the Vipps MobilePay app.', 'woo-vipps' );
-			$subscription->set_status( 'cancelled', $message );
-			$subscription->save();
-		}
-	}
-
-	public function cart_supports_checkout( $cart = null ) {
-		if ( ! $cart ) {
-			$cart = WC()->cart;
-		}
-
-		if ( ! $cart ) {
-			return false;
-		}
-
-		# Not supported by Vipps MobilePay Checkout
-		if ( $cart->cart_contents_total <= 0 ) {
-			return false;
-		}
-
-		$supports = WC_Vipps_Recurring::get_instance()->gateway_should_be_active();
-
-		return apply_filters( 'wc_vipps_recurring_cart_supports_checkout', $supports, $cart );
-	}
-
-	public function checkout_is_available() {
-		if ( ! $this->checkout_enabled
-		     || ! $this->is_available()
-		     || ! $this->cart_supports_checkout() ) {
-			return false;
-		}
-
-		$checkout_id = wc_get_page_id( 'vipps_recurring_checkout' );
-		if ( ! $checkout_id ) {
-			return false;
-		}
-
-		if ( ! get_post_status( $checkout_id ) ) {
-			delete_option( 'woocommerce_vipps_recurring_checkout_page_id' );
-
-			return false;
-		}
-
-		return apply_filters( 'wc_vipps_recurring_checkout_available', $checkout_id, $this );
-	}
-
-	// Creating a partial order & subscription
-	// Heavily based on the single payments plugins logic. The comments are also copied for readability.
-	/**
-	 * @throws WC_Data_Exception
-	 * @throws Exception
-	 */
-	public function create_partial_order( $checkout = false ): int {
-		$order_id = apply_filters( 'woocommerce_create_order', null );
-		if ( $order_id ) {
-			return $order_id;
-		}
-
-		// This is necessary for some plugins, like YITH Dynamic Pricing, that adds filters to get_price depending on whether is_checkout is true.
-		// so basically, since we are impersonating WC_Checkout here, we should define this constant too
-		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
-
-		// In *some* cases you may need to actually load classes and reload the cart, because some plugins do not load when DOING_AJAX.
-		do_action( 'wc_vipps_recurring_express_checkout_before_calculate_totals' );
-
-		WC()->cart->calculate_fees();
-		WC()->cart->calculate_shipping();
-		WC()->cart->calculate_totals();
-		do_action( 'wc_vipps_recurring_before_create_express_checkout_order', WC()->cart );
-
-		$order_id  = absint( WC()->session->get( 'order_awaiting_payment' ) );
-		$cart_hash = WC()->cart->get_cart_hash();
-		$order     = $order_id ? wc_get_order( $order_id ) : null;
-
-		/**
-		 * If there is an order pending payment, we can resume it here so
-		 * long as it has not changed. If the order has changed, i.e.
-		 * different items or cost, create a new order. We use a hash to
-		 * detect changes which is based on cart items + order total.
-		 */
-		if ( $order && $order->has_cart_hash( $cart_hash ) && $order->has_status( array( 'pending', 'failed' ) ) ) {
-			/**
-			 * Indicates that we are resuming checkout for an existing order (which is pending payment, and which
-			 * has not changed since it was added to the current shopping session).
-			 *
-			 * @param int $order_id The ID of the order being resumed.
-			 *
-			 * @since 3.0.0 or earlier
-			 *
-			 */
-			do_action( 'woocommerce_resume_order', $order_id );
-
-			// Remove all items - we will re-add them later.
-			$order->remove_order_items();
-		} else {
-			$order = new WC_Order();
-		}
-
-		// We store this in the order, so we don't have to access the cart when initiating payment. This allows us to restart orders etc.
-		$needs_shipping = WC()->cart->needs_shipping();
-
-		$order->set_payment_method( $this );
-
-		try {
-			if ( $checkout ) {
-				$order->update_meta_data( WC_Vipps_Recurring_Helper::META_ORDER_IS_CHECKOUT, 1 );
-				$order->set_payment_method_title( 'Vipps/MobilePay Recurring Checkout' );
-			} else {
-				$order->set_payment_method_title( 'Vipps/MobilePay Recurring Express Checkout' );
-			}
-
-			// We use 'checkout' as the created_via key as per requests, but allow merchants to use their own.
-			$created_via = apply_filters( 'wc_vipps_recurring_express_checkout_created_via', 'checkout', $order, $checkout );
-
-			$order->set_cart_hash( $cart_hash );
-			$order->set_created_via( $created_via );
-
-			$order->update_meta_data( WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS, 1 );
-
-			# To help with address fields, scope etc in initiate payment
-			$order->update_meta_data( WC_Vipps_Recurring_Helper::META_ORDER_NEEDS_SHIPPING, $needs_shipping );
-
-			$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) );
-			$order->set_currency( get_woocommerce_currency() );
-			$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
-			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );
-			$order->set_customer_user_agent( wc_get_user_agent() );
-			$order->set_discount_total( WC()->cart->get_discount_total() );
-			$order->set_discount_tax( WC()->cart->get_discount_tax() );
-			$order->set_cart_tax( WC()->cart->get_cart_contents_tax() + WC()->cart->get_fee_tax() );
-
-			// Use these methods directly - they should be safe.
-			WC()->checkout->create_order_line_items( $order, WC()->cart );
-			WC()->checkout->create_order_fee_lines( $order, WC()->cart );
-			WC()->checkout->create_order_tax_lines( $order, WC()->cart );
-			WC()->checkout->create_order_coupon_lines( $order, WC()->cart );
-
-			if ( $needs_shipping ) {
-				WC()->checkout->create_order_shipping_lines( $order, WC()->session->get( 'chosen_shipping_methods' ), WC()->shipping->get_packages() );
-			}
-
-			do_action( 'wc_vipps_recurring_before_calculate_totals_partial_order', $order );
-			$order->calculate_totals();
-
-			// Added to support third-party plugins that wants to do stuff with the order before it is saved.
-			do_action( 'woocommerce_checkout_create_order', $order, array() );
-
-			$order_id = $order->save();
-
-			do_action( 'wc_vipps_recurring_express_checkout_order_created', $order_id );
-
-			// Normally done by the WC_Checkout::create_order method, so call it here too.
-			do_action( 'woocommerce_checkout_update_order_meta', $order_id, array() );
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Initialise Gateway Settings Form Fields
+     */
+    public function init_form_fields(): void {
+        $this->form_fields = require( __DIR__ . '/admin/vipps-recurring-settings.php' );
+
+        // Set some options and default values
+        $this->form_fields['brand']['default'] = $this->detect_default_brand();
+
+        $this->form_fields['order_prefix']['default'] = WC_Vipps_Recurring::get_instance()->generate_order_prefix();
+
+        if ( $this->get_option( 'test_mode' ) === "yes" || WC_VIPPS_RECURRING_TEST_MODE ) {
+            $this->form_fields['title_test_api'] = [
+                'type'  => 'title',
+                'title' => __( 'Test API settings', 'woo-vipps' ),
+            ];
+
+            $this->form_fields['test_merchant_serial_number'] = $this->form_fields['merchant_serial_number'];
+            $this->form_fields['test_client_id']              = $this->form_fields['client_id'];
+            $this->form_fields['test_secret_key']             = $this->form_fields['secret_key'];
+            $this->form_fields['test_subscription_key']       = $this->form_fields['subscription_key'];
+        }
+    }
+
+    function validate_text_field( $key, $value ) {
+        if ( $key !== 'order_prefix' ) {
+            return parent::validate_text_field( $key, $value );
+        }
+
+        return preg_replace( '![^a-zA-Z0-9\-]!', '', $value );
+    }
+
+    public function detect_default_brand(): string {
+        $locale         = get_locale();
+        $store_location = wc_get_base_location();
+        $store_country  = $store_location['country'] ?? '';
+        $currency       = get_woocommerce_currency();
+
+        $default_brand = "mobilepay";
+
+        // If store location, locale, or currency is Norwegian, use Vipps
+        if ( $store_country == "NO" || preg_match( "/_NO/", $locale ) || $currency == "NOK" ) {
+            $default_brand = "vipps";
+        }
+
+        return $default_brand;
+    }
+
+    /**
+     * @param $what
+     */
+    private function admin_error( $what ): void {
+        add_action( 'admin_notices', static function () use ( $what ) {
+            echo "<div class='notice notice-error is-dismissible'><p>$what</p></div>";
+        } );
+    }
+
+    /**
+     * @param $what
+     */
+    private function admin_notify( $what, $type = "info" ): void {
+        add_action( 'admin_notices', static function () use ( $what, $type ) {
+            echo "<div class='notice notice-$type is-dismissible'><p>$what</p></div>";
+        } );
+    }
+
+    public function process_admin_options(): bool {
+        $saved = parent::process_admin_options();
+        delete_transient( '_vipps_keyset' ); // Same transient as for the payment api IOK 2024-12-03
+
+        $this->init_form_fields();
+
+        if ( $this->get_option( 'enabled' ) === "yes" ) {
+            $this->webhook_initialize();
+
+            try {
+                $this->api->get_access_token( true );
+                update_option( WC_Vipps_Recurring_Helper::OPTION_CONFIGURED, 1, true );
+
+                $this->admin_notify( __( 'Successfully authenticated with the Vipps/MobilePay API', 'woo-vipps' ) );
+            } catch ( Exception $e ) {
+                update_option( WC_Vipps_Recurring_Helper::OPTION_CONFIGURED, 0, true );
+
+                /* translators: %s: the error message returned from Vipps/MobilePay */
+                $this->admin_error( sprintf( __( 'Could not authenticate with the Vipps/MobilePay API: %s', 'woo-vipps' ), $e->getMessage() ) );
+            }
+        }
+
+        $checkout_enabled = $this->get_option( 'checkout_enabled' ) === "yes";
+        $test_mode        = $this->get_option( 'test_mode' ) === "yes" || WC_VIPPS_RECURRING_TEST_MODE;
+
+        // Validate that we have an MSN set, as it is required in Checkout.
+        $merchant_serial_number = $test_mode ? $this->get_option( 'test_merchant_serial_number' ) : $this->get_option( 'merchant_serial_number' );
+        if ( empty( $merchant_serial_number ) ) {
+            $this->admin_notify( __( 'You need to provide a Merchant Serial Number before you can enable Checkout.', 'woo-vipps' ), "error" );
+
+            // Disable checkout if we do not have an MSN value.
+            $this->update_option( 'checkout_enabled', 'no' );
+            update_option( WC_Vipps_Recurring_Helper::OPTION_CHECKOUT_ENABLED, false, true );
+
+            return $saved;
+        }
+
+        update_option( WC_Vipps_Recurring_Helper::OPTION_CHECKOUT_ENABLED, $checkout_enabled, true );
+
+        if ( $checkout_enabled ) {
+            WC_Vipps_Recurring::get_instance()->maybe_create_checkout_page();
+        }
+
+        return $saved;
+    }
+
+    /**
+     * @param $statuses
+     *
+     * @return array
+     */
+    public function append_valid_statuses_for_payment_complete( $statuses ): array {
+        $statuses = array_merge( $statuses, $this->statuses_to_attempt_capture );
+
+        if ( $this->transition_renewals_to_completed && ! in_array( 'completed', $statuses, true ) ) {
+            $statuses[] = 'completed';
+        }
+
+        return $statuses;
+    }
+
+    /**
+     * @param $payment_meta
+     * @param $subscription
+     *
+     * @return mixed
+     */
+    public function add_subscription_payment_meta( $payment_meta, $subscription ) {
+        $payment_meta[ $this->id ] = [
+            'post_meta' => [
+                '_agreement_id' => [
+                    'value' => WC_Vipps_Recurring_Helper::get_meta( $subscription, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID ),
+                    'label' => __( 'Vipps/MobilePay Agreement ID', 'woo-vipps' ),
+                ]
+            ],
+        ];
+
+        return $payment_meta;
+    }
+
+    /**
+     * @param $payment_method_id
+     * @param $payment_meta
+     *
+     * @throws Exception
+     */
+    public function validate_subscription_payment_meta( $payment_method_id, $payment_meta ): void {
+        if ( $this->id !== $payment_method_id ) {
+            return;
+        }
+
+        $agreement_id = $payment_meta['post_meta']['_agreement_id']['value'];
+
+        try {
+            $this->api->get_agreement( $agreement_id );
+        } catch ( Exception $e ) {
+            throw new \RuntimeException( __( 'This Vipps/MobilePay agreement ID is invalid.', 'woo-vipps' ) );
+        }
+    }
+
+    public function cart_needs_payment( $needs_payment, $cart ) {
+        $cart_switch_items = wcs_cart_contains_switches();
+
+        if ( false === $needs_payment && 0 == $cart->total && false !== $cart_switch_items && ! wcs_is_manual_renewal_required() ) {
+            foreach ( $cart_switch_items as $cart_switch_details ) {
+                $subscription = wcs_get_subscription( $cart_switch_details['subscription_id'] );
+
+                if ( $this->id === $subscription->get_payment_method() ) {
+                    $needs_payment = true;
+                    break;
+                }
+            }
+        }
+
+        return $needs_payment;
+    }
+
+    /**
+     * @param $subscription
+     */
+    public function handle_subscription_switch_completed( $subscription ): void {
+        $payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $subscription );
+        if ( $this->id !== $payment_method ) {
+            return;
+        }
+
+        WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Subscription switch completed", WC_Vipps_Recurring_Helper::get_id( $subscription ) ) );
+
+        WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX );
+        $subscription->save();
+
+        try {
+            $this->maybe_update_subscription_details_in_app( WC_Vipps_Recurring_Helper::get_id( $subscription ) );
+        } catch ( Exception $exception ) {
+            // do nothing, we don't want to throw an error in the user's face
+        }
+    }
+
+    /**
+     * @param WC_Subscription $subscription
+     * @param $new_status
+     * @param $old_status
+     */
+    public function maybe_handle_subscription_status_transitions( WC_Subscription $subscription, $new_status, $old_status ): void {
+        $payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $subscription );
+
+        /*
+         * note: if we reverse the if statement to reduce nesting I fear we may run into an early stop of code execution issue
+         */
+        if ( $this->id === $payment_method ) {
+            $order = wc_get_order( WC_Vipps_Recurring_Helper::get_id( $subscription ) );
+
+            if ( $new_status === 'pending-cancel' ) {
+                WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
+                WC_Vipps_Recurring_Helper::update_meta_data(
+                    $order,
+                    WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX,
+                    __( 'Pending cancellation', 'woo-vipps' )
+                );
+
+                $order->save();
+            }
+
+            if ( $new_status === 'cancelled' ) {
+                WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
+                WC_Vipps_Recurring_Helper::update_meta_data(
+                    $order,
+                    WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX,
+                    __( 'Cancelled', 'woo-vipps' )
+                );
+
+                $order->save();
+            }
+
+            if ( $new_status === 'on-hold' ) {
+                WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
+                WC_Vipps_Recurring_Helper::update_meta_data(
+                    $order,
+                    WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX,
+                    __( 'On hold', 'woo-vipps' )
+                );
+
+                $order->save();
+            }
+
+            if ( ( $old_status === 'pending-cancel' || $old_status === 'on-hold' ) && $new_status !== 'cancelled' ) {
+                WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
+                $order->delete_meta_data( WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX );
+
+                $order->save();
+            }
+        }
+    }
+
+    /**
+     * Don't transfer Vipps/MobilePay idempotency key or any other keys unique to a charge or order to resubscribe orders.
+     *
+     * @param mixed $resubscribe_order The order created for the customer to resubscribe to the old expired/cancelled subscription
+     */
+    public function delete_resubscribe_meta( $resubscribe_order ): void {
+        WC_Vipps_Recurring_Helper::delete_meta_data( $resubscribe_order, WC_Vipps_Recurring_Helper::META_CHARGE_ID );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $resubscribe_order, WC_Vipps_Recurring_Helper::META_CHARGE_CAPTURED );
+
+        WC_Vipps_Recurring_Helper::delete_meta_data( $resubscribe_order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $resubscribe_order, WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $resubscribe_order, WC_Vipps_Recurring_Helper::META_ORDER_EXPRESS_AUTH_TOKEN );
+
+        $this->delete_renewal_meta( $resubscribe_order );
+    }
+
+    /**
+     * Don't transfer Vipps/MobilePay idempotency key or any other keys unique to a charge or order to renewal orders.
+     *
+     * @param mixed $renewal_order The renewal order
+     */
+    public function delete_renewal_meta( WC_Order $renewal_order ) {
+        // Do not delete the idempotency key if the order has failed previously
+        $has_failed_previously = WC_Vipps_Recurring_Helper::get_meta( $renewal_order, '_failed_renewal_order' );
+        if ( $has_failed_previously !== "yes" ) {
+            WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_ORDER_IDEMPOTENCY_KEY );
+        }
+
+        WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_FAILED );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_FAILED_DESCRIPTION );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_FAILED_REASON );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_LATEST_STATUS );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP_DESCRIPTION_PREFIX );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_CHARGE_CAPTURED );
+
+        WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS );
+        WC_Vipps_Recurring_Helper::delete_meta_data( $renewal_order, WC_Vipps_Recurring_Helper::META_ORDER_EXPRESS_AUTH_TOKEN );
+
+        $renewal_order->save();
+
+        return $renewal_order;
+    }
+
+    /**
+     * @param $order_id
+     */
+    public function maybe_cancel_due_charge( $order_id ): void {
+        $order = wc_get_order( $order_id );
+
+        $payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $order );
+        if ( $this->id !== $payment_method ) {
+            return;
+        }
+
+        $agreement_id = WC_Vipps_Recurring_Helper::get_agreement_id_from_order( $order );
+        $charge_id    = WC_Vipps_Recurring_Helper::get_charge_id_from_order( $order );
+
+        if ( $agreement_id === null || $charge_id === null ) {
+            WC_Vipps_Recurring_Helper::delete_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING );
+
+            return;
+        }
+
+        $pending_charge = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING );
+
+        if ( $pending_charge ) {
+            try {
+                if ( get_transient( 'maybe_cancel_due_charge_lock' . $order_id ) ) {
+                    return;
+                }
+
+                set_transient( 'maybe_cancel_due_charge_lock' . $order_id, uniqid( '', true ), 30 );
+
+                $charge = $this->api->get_charge( $agreement_id, $charge_id );
+                if ( in_array( $charge->status, [
+                    WC_Vipps_Charge::STATUS_DUE,
+                    WC_Vipps_Charge::STATUS_PENDING
+                ], true ) ) {
+                    $idempotency_key = $this->get_idempotency_key( $order );
+                    $this->api->cancel_charge( $agreement_id, $charge_id, $idempotency_key );
+                    $order->add_order_note( __( 'Cancelled due charge in Vipps/MobilePay.', 'woo-vipps' ) );
+                    WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Cancelled DUE charge with ID: %s for agreement with ID: %s', $order_id, $charge_id, $agreement_id ) );
+                }
+            } catch ( Exception $e ) {
+                $order->add_order_note( __( 'Could not cancel charge in Vipps/MobilePay. Please manually check the status of this order if you plan to process a new renewal order!', 'woo-vipps' ) );
+                WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Failed cancelling DUE charge with ID: %s for agreement with ID: %s. Error: %s', $order_id, $charge_id, $agreement_id, $e->getMessage() ) );
+            }
+        }
+    }
+
+    /**
+     * When renewing early from a different gateway WooCommerce does not update the gateway for you.
+     * If we detect that you've renewed early with Vipps/MobilePay and the gateway is not set to Vipps/MobilePay we will
+     * update the gateway for you.
+     *
+     * @param $order_id
+     *
+     * @return void
+     * @throws WC_Vipps_Recurring_Exception
+     */
+    public function after_renew_early_from_another_gateway( $order_id ): void {
+        if ( ! wcs_order_contains_early_renewal( $order_id ) ) {
+            return;
+        }
+
+        $subscriptions = $this->get_subscriptions_for_order( $order_id );
+
+        foreach ( $subscriptions as $subscription ) {
+            if ( $subscription->get_payment_method() === $this->id ) {
+                continue;
+            }
+
+            if ( ! WC_Vipps_Recurring_Helper::get_meta( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_RENEWING_WITH_VIPPS ) ) {
+                continue;
+            }
+
+            $agreement = $this->get_agreement_from_order( $subscription );
+            if ( ! $agreement || $agreement->status !== WC_Vipps_Agreement::STATUS_ACTIVE ) {
+                continue;
+            }
+
+            $subscription->set_payment_method( $this->id );
+            WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_RENEWING_WITH_VIPPS, false );
+            $subscription->save();
+        }
+    }
+
+    /**
+     * Prevent an order from being transitioned to "processing" when the status is already "completed"
+     *
+     * @param $status
+     * @param $order_id
+     * @param $order
+     *
+     * @return string|null
+     */
+    public function prevent_backwards_transition_on_completed_order( $status, $order_id, $order ): ?string {
+        if ( $status === 'processing'
+             && $order->has_status( 'completed' )
+             && $order->get_payment_method() === $this->id ) {
+            return 'completed';
+        }
+
+        return $status;
+    }
+
+    public function update_agreement_price_in_app( $and_taxes, $subscription ) {
+        if ( ! wcs_is_subscription( $subscription ) ) {
+            return;
+        }
+
+        $payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $subscription );
+        if ( $this->id !== $payment_method ) {
+            return;
+        }
+
+        WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Totals were recalculated. Marking subscription for update in the Vipps/MobilePay app.', WC_Vipps_Recurring_Helper::get_id( $subscription ) ) );
+        WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP, 1 );
+        $subscription->save();
+    }
+
+    /**
+     * Initialize webhooks if we don't already have one
+     *
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     * @throws WC_Vipps_Recurring_Config_Exception
+     */
+    private function webhook_initialize_initial() {
+        $msn = $this->merchant_serial_number;
+
+        // We cannot use webhooks without the MSN being set.
+        if ( empty( $msn ) ) {
+            return;
+        }
+
+        $webhooks       = $this->api->get_webhooks();
+        $local_webhooks = $this->webhook_get_local();
+        $callback_url   = $this->webhook_callback_url();
+
+        // Delete webhooks that are not for our MSN + hostname combination. This prevents us from conflicting with Pay with WooCommerce for Vipps and MobilePay
+        $deletion_tracker = [];
+
+        $webhook_initialized = false;
+
+        foreach ( $webhooks['webhooks'] as $webhook ) {
+            if ( ! isset( $local_webhooks[ $msn ][ $webhook['id'] ] ) ) {
+                // this webhook is not created by us, so we can continue
+                continue;
+            }
+
+            // If we have multiple webhooks for our MSN we can delete the other ones. We do not want duplicates.
+            if ( $webhook_initialized ) {
+                $deletion_tracker[] = $webhook['id'];
+            }
+
+            $webhook_initialized = true;
+        }
+
+        // Create webhook and save it to WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS
+        if ( ! $webhook_initialized ) {
+            $response = $this->api->register_webhook();
+
+            $local_webhooks[ $msn ][ $response['id'] ] = [
+                'secret' => $response['secret'],
+                'url'    => $callback_url
+            ];
+        }
+
+        // Delete superfluous webhooks
+        if ( ! empty( $deletion_tracker ) ) {
+            foreach ( $deletion_tracker as $id ) {
+                try {
+                    $this->api->delete_webhook( $id );
+                    unset( $local_webhooks[ $msn ][ $id ] );
+                } catch ( Exception $e ) {
+                    WC_Vipps_Recurring_Logger::log( sprintf( 'Failed to delete webhook %s. Error: %s', $id, $e->getMessage() ) );
+                }
+            }
+        }
+
+        update_option( WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS, $local_webhooks );
+    }
+
+    /**
+     * Check that our local webhooks point to this site.
+     * If they don't we should delete them, otherwise we end up with hitting the limit of 5.
+     *
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     * @throws WC_Vipps_Recurring_Config_Exception
+     */
+    public function webhook_ensure_this_site(): bool {
+        $msn = $this->merchant_serial_number;
+
+        // We cannot use webhooks without the MSN being set.
+        if ( empty( $msn ) ) {
+            return false;
+        }
+
+        $local_webhooks    = $this->webhook_get_local();
+        $callback_url      = $this->webhook_callback_url();
+        $callback_url_base = strtok( $callback_url, "?" );
+
+        // Make sure we don't do this more than once every 30 minutes, and only if the callback url base changes.
+        $webhook_transient = "vipps-recurring-webhooks-site";
+        if ( get_transient( $webhook_transient ) === $callback_url_base ) {
+            return true;
+        }
+
+        set_transient( $webhook_transient, $callback_url_base, 1800 );
+
+        if ( empty( $local_webhooks[ $msn ] ) ) {
+            return false;
+        }
+
+        $remote_webhooks = $this->api->get_webhooks();
+
+        $ok = true;
+        foreach ( $local_webhooks[ $msn ] as $webhook_id => $webhook ) {
+            $webhook_base_url = strtok( $webhook['url'], "?" );
+
+            if ( $webhook_base_url === $callback_url_base ) {
+                continue;
+            }
+
+            // Check that this webhookId indeed exists in $remote_webhooks before we attempt to delete it
+            $webhook_exists = ! empty( array_filter( $remote_webhooks['webhooks'], function ( $remote_webhook ) use ( $webhook_id ) {
+                return $remote_webhook['id'] === $webhook_id;
+            } ) );
+
+            if ( $webhook_exists ) {
+                $this->api->delete_webhook( $webhook_id );
+            }
+
+            unset( $local_webhooks[ $msn ][ $webhook_id ] );
+
+            $ok = false;
+        }
+
+        update_option( WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS, $local_webhooks );
+
+        return $ok;
+    }
+
+    /**
+     * Delete all webhooks during uninstall for this MSN
+     *
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     * @throws WC_Vipps_Recurring_Config_Exception
+     */
+    public function webhook_teardown() {
+        $msn = $this->merchant_serial_number;
+
+        if ( empty( $msn ) ) {
+            return;
+        }
+
+        $local_webhooks = $this->webhook_get_local();
+
+        if ( empty( $local_webhooks[ $msn ] ) ) {
+            return;
+        }
+
+        $remote_webhooks = $this->api->get_webhooks();
+
+        // We can have multiple MSNs, hence the nested loop
+        foreach ( $local_webhooks as $webhooks ) {
+            foreach ( $webhooks as $webhook_id => $webhook ) {
+                // Check that this webhookId indeed exists in $remote_webhooks before we attempt to delete it
+                $webhook_exists = ! empty( array_filter( $remote_webhooks['webhooks'], function ( $remote_webhook ) use ( $webhook_id ) {
+                    return $remote_webhook['id'] === $webhook_id;
+                } ) );
+
+                if ( ! $webhook_exists ) {
+                    continue;
+                }
+
+                $this->api->delete_webhook( $webhook_id );
+            }
+        }
+
+        delete_option( WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS );
+    }
+
+    public function webhook_get_local(): array {
+        return get_option( WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS, [ $this->merchant_serial_number => [] ] );
+    }
+
+    public function webhook_initialize() {
+        try {
+            $this->webhook_ensure_this_site();
+            $this->webhook_initialize_initial();
+        } catch ( Exception $e ) {
+            WC_Vipps_Recurring_Logger::log( sprintf( 'Failed to initialize webhooks. Error: %s', $e->getMessage() ) );
+        }
+    }
+
+    public function webhook_callback_url(): string {
+        $base_url = home_url( '/', 'https' );
+
+        $args   = [ 'callback' => 'webhook' ];
+        $action = 'wc_gateway_vipps_recurring';
+
+        if ( ! get_option( 'permalink_structure' ) ) {
+            $args['wc-api'] = $action;
+        } else {
+            $base_url = trailingslashit( home_url( "wc-api/$action", 'https' ) );
+        }
+
+        return add_query_arg( $args, $base_url );
+    }
+
+    private function maybe_get_subscription_from_agreement_webhook( array $webhook_data ) {
+        $order_id = $webhook_data['agreementExternalId'];
+
+        // Check if agreementExternalId is not set, we can get the subscription from agreementId
+        if ( empty( $order_id ) && isset( $webhook_data['agreementId'] ) ) {
+            $agreement_id = $webhook_data['agreementId'];
+
+            $subscriptions = wcs_get_subscriptions( [
+                'subscriptions_per_page' => 1,
+                'subscription_status'    => [ 'active', 'pending', 'on-hold' ],
+                'meta_query'             => [
+                    [
+                        'key'     => WC_Vipps_Recurring_Helper::META_AGREEMENT_ID,
+                        'compare' => '=',
+                        'value'   => $agreement_id
+                    ]
+                ]
+            ] );
+
+            if ( ! empty( $subscriptions ) ) {
+                return array_pop( $subscriptions );
+            }
+        }
+
+        // If the order id is not a subscription, we can get the subscription from the order
+        if ( ! empty( $order_id ) && ! wcs_is_subscription( $order_id ) ) {
+            $order         = wc_get_order( $order_id );
+            $subscriptions = wcs_get_subscriptions_for_order( $order );
+
+            if ( ! empty( $subscriptions ) ) {
+                return array_pop( $subscriptions );
+            }
+        }
+
+        // Otherwise the order_id is either empty, or a subscription
+        return $order_id;
+    }
+
+    /**
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     * @throws WC_Vipps_Recurring_Config_Exception
+     */
+    public function handle_webhook_callback( array $webhook_data ): void {
+        WC_Vipps_Recurring_Logger::log( sprintf( "Handling webhook with data: %s", json_encode( $webhook_data ) ) );
+
+        $event_type = $webhook_data['eventType'];
+
+        if ( in_array( $event_type, [
+            'recurring.charge-reserved.v1',
+            'recurring.charge-captured.v1',
+            'recurring.charge-canceled.v1',
+            'recurring.charge-failed.v1',
+        ] ) ) {
+            $order_id = $webhook_data['chargeExternalId'];
+
+            if ( empty( $order_id ) ) {
+                $charge_id = $webhook_data['chargeId'];
+
+                $orders = wc_get_orders( [
+                    'limit'          => 1,
+                    'meta_query'     => [
+                        [
+                            'key'     => WC_Vipps_Recurring_Helper::META_CHARGE_ID,
+                            'compare' => '=',
+                            'value'   => $charge_id
+                        ]
+                    ],
+                    'payment_method' => $this->id,
+                    'order_by'       => 'post_date'
+                ] );
+
+                $order = array_pop( $orders );
+
+                if ( $order ) {
+                    $order_id = WC_Vipps_Recurring_Helper::get_id( $order );
+                }
+            }
+
+            if ( empty( $charge_id ) ) {
+                return;
+            }
+
+            $this->check_charge_status( $order_id );
+        }
+
+        // Customers can now cancel their agreements directly from the app.
+        if ( $event_type === 'recurring.agreement-stopped.v1' ) {
+            // If the initiator of this webhook is ourselves, we must discard it.
+            // Otherwise, we risk cancelling payment gateway changes etc.
+            if ( $webhook_data['actor'] === 'MERCHANT' ) {
+                return;
+            }
+
+            $subscription_id = $this->maybe_get_subscription_from_agreement_webhook( $webhook_data );
+            if ( empty( $subscription_id ) ) {
+                return;
+            }
+
+            $subscription = wcs_get_subscription( $subscription_id );
+
+            if ( empty( $subscription ) ) {
+                return;
+            }
+
+            $message = __( 'Subscription cancelled by the customer via the Vipps MobilePay app.', 'woo-vipps' );
+            $subscription->set_status( 'cancelled', $message );
+            $subscription->save();
+        }
+    }
+
+    public function cart_supports_checkout( $cart = null ) {
+        if ( ! $cart ) {
+            $cart = WC()->cart;
+        }
+
+        if ( ! $cart ) {
+            return false;
+        }
+
+        # Not supported by Vipps MobilePay Checkout
+        if ( $cart->cart_contents_total <= 0 ) {
+            return false;
+        }
+
+        $supports = WC_Vipps_Recurring::get_instance()->gateway_should_be_active();
+
+        return apply_filters( 'wc_vipps_recurring_cart_supports_checkout', $supports, $cart );
+    }
+
+    public function checkout_is_available() {
+        if ( ! $this->checkout_enabled
+             || ! $this->is_available()
+             || ! $this->cart_supports_checkout() ) {
+            return false;
+        }
+
+        $checkout_id = wc_get_page_id( 'vipps_recurring_checkout' );
+        if ( ! $checkout_id ) {
+            return false;
+        }
+
+        if ( ! get_post_status( $checkout_id ) ) {
+            delete_option( 'woocommerce_vipps_recurring_checkout_page_id' );
+
+            return false;
+        }
+
+        return apply_filters( 'wc_vipps_recurring_checkout_available', $checkout_id, $this );
+    }
+
+    // Creating a partial order & subscription
+    // Heavily based on the single payments plugins logic. The comments are also copied for readability.
+    /**
+     * @throws WC_Data_Exception
+     * @throws Exception
+     */
+    public function create_partial_order( $checkout = false ): int {
+        $order_id = apply_filters( 'woocommerce_create_order', null );
+        if ( $order_id ) {
+            return $order_id;
+        }
+
+        // This is necessary for some plugins, like YITH Dynamic Pricing, that adds filters to get_price depending on whether is_checkout is true.
+        // so basically, since we are impersonating WC_Checkout here, we should define this constant too
+        wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
+
+        // In *some* cases you may need to actually load classes and reload the cart, because some plugins do not load when DOING_AJAX.
+        do_action( 'wc_vipps_recurring_express_checkout_before_calculate_totals' );
+
+        WC()->cart->calculate_fees();
+        WC()->cart->calculate_shipping();
+        WC()->cart->calculate_totals();
+        do_action( 'wc_vipps_recurring_before_create_express_checkout_order', WC()->cart );
+
+        $order_id  = absint( WC()->session->get( 'order_awaiting_payment' ) );
+        $cart_hash = WC()->cart->get_cart_hash();
+        $order     = $order_id ? wc_get_order( $order_id ) : null;
+
+        /**
+         * If there is an order pending payment, we can resume it here so
+         * long as it has not changed. If the order has changed, i.e.
+         * different items or cost, create a new order. We use a hash to
+         * detect changes which is based on cart items + order total.
+         */
+        if ( $order && $order->has_cart_hash( $cart_hash ) && $order->has_status( array( 'pending', 'failed' ) ) ) {
+            /**
+             * Indicates that we are resuming checkout for an existing order (which is pending payment, and which
+             * has not changed since it was added to the current shopping session).
+             *
+             * @param int $order_id The ID of the order being resumed.
+             *
+             * @since 3.0.0 or earlier
+             *
+             */
+            do_action( 'woocommerce_resume_order', $order_id );
+
+            // Remove all items - we will re-add them later.
+            $order->remove_order_items();
+        } else {
+            $order = new WC_Order();
+        }
+
+        // We store this in the order, so we don't have to access the cart when initiating payment. This allows us to restart orders etc.
+        $needs_shipping = WC()->cart->needs_shipping();
+
+        $order->set_payment_method( $this );
+
+        try {
+            if ( $checkout ) {
+                $order->update_meta_data( WC_Vipps_Recurring_Helper::META_ORDER_IS_CHECKOUT, 1 );
+                $order->set_payment_method_title( 'Vipps/MobilePay Recurring Checkout' );
+            } else {
+                $order->set_payment_method_title( 'Vipps/MobilePay Recurring Express Checkout' );
+            }
+
+            // We use 'checkout' as the created_via key as per requests, but allow merchants to use their own.
+            $created_via = apply_filters( 'wc_vipps_recurring_express_checkout_created_via', 'checkout', $order, $checkout );
+
+            $order->set_cart_hash( $cart_hash );
+            $order->set_created_via( $created_via );
+
+            $order->update_meta_data( WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS, 1 );
+
+            # To help with address fields, scope etc in initiate payment
+            $order->update_meta_data( WC_Vipps_Recurring_Helper::META_ORDER_NEEDS_SHIPPING, $needs_shipping );
+
+            $order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) );
+            $order->set_currency( get_woocommerce_currency() );
+            $order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
+            $order->set_customer_ip_address( WC_Geolocation::get_ip_address() );
+            $order->set_customer_user_agent( wc_get_user_agent() );
+            $order->set_discount_total( WC()->cart->get_discount_total() );
+            $order->set_discount_tax( WC()->cart->get_discount_tax() );
+            $order->set_cart_tax( WC()->cart->get_cart_contents_tax() + WC()->cart->get_fee_tax() );
+
+            // Use these methods directly - they should be safe.
+            WC()->checkout->create_order_line_items( $order, WC()->cart );
+            WC()->checkout->create_order_fee_lines( $order, WC()->cart );
+            WC()->checkout->create_order_tax_lines( $order, WC()->cart );
+            WC()->checkout->create_order_coupon_lines( $order, WC()->cart );
+
+            if ( $needs_shipping ) {
+                WC()->checkout->create_order_shipping_lines( $order, WC()->session->get( 'chosen_shipping_methods' ), WC()->shipping->get_packages() );
+            }
+
+            do_action( 'wc_vipps_recurring_before_calculate_totals_partial_order', $order );
+            $order->calculate_totals();
+
+            // Added to support third-party plugins that wants to do stuff with the order before it is saved.
+            do_action( 'woocommerce_checkout_create_order', $order, array() );
+
+            $order_id = $order->save();
+
+            do_action( 'wc_vipps_recurring_express_checkout_order_created', $order_id );
+
+            // Normally done by the WC_Checkout::create_order method, so call it here too.
+            do_action( 'woocommerce_checkout_update_order_meta', $order_id, array() );
 
 //			// It isn't possible to remove the javascript or 'after order notice' actions, because these are added as closures
 //			// before anything else is run. But we can disable the hook that saves data.
 //			if (WC_Gateway_Vipps::instance()->get_option('vippsorderattribution') != 'yes') {
-			remove_all_filters( 'woocommerce_order_save_attribution_data' );
+            remove_all_filters( 'woocommerce_order_save_attribution_data' );
 //			}
 
-			do_action( 'woocommerce_checkout_order_created', $order );
-		} catch ( Exception $exception ) {
-			if ( $order instanceof WC_Order ) {
-				$order->get_data_store()->release_held_coupons( $order );
-				do_action( 'woocommerce_checkout_order_exception', $order );
-			}
+            do_action( 'woocommerce_checkout_order_created', $order );
+        } catch ( Exception $exception ) {
+            if ( $order instanceof WC_Order ) {
+                $order->get_data_store()->release_held_coupons( $order );
+                do_action( 'woocommerce_checkout_order_exception', $order );
+            }
 
-			// Any errors gets passed upstream
-			throw $exception;
-		}
+            // Any errors gets passed upstream
+            throw $exception;
+        }
 
-		return $order_id;
-	}
+        return $order_id;
+    }
 
-	/**
-	 * @throws Exception
-	 */
-	public function create_or_get_anonymous_system_customer(): WC_Customer {
-		$customer_id = get_option( WC_Vipps_Recurring_Helper::OPTION_ANONYMOUS_SYSTEM_CUSTOMER_ID );
+    /**
+     * @throws Exception
+     */
+    public function create_or_get_anonymous_system_customer(): WC_Customer {
+        $customer_id = get_option( WC_Vipps_Recurring_Helper::OPTION_ANONYMOUS_SYSTEM_CUSTOMER_ID );
 
-		// Create a user if it does not exist
-		if ( ! get_user_by( 'ID', $customer_id ) ) {
-			$email       = WC_Vipps_Recurring_Helper::FAKE_USER_EMAIL;
-			$username    = wc_create_new_customer_username( $email );
-			$customer_id = wc_create_new_customer( $email, $username, null, [
-				'first_name'    => 'Anonymous Vipps MobilePay Customer',
-				'user_nicename' => __( 'Anonymous Vipps MobilePay Customer', 'woo-vipps' ),
-			] );
+        // Create a user if it does not exist
+        if ( ! get_user_by( 'ID', $customer_id ) ) {
+            $email       = WC_Vipps_Recurring_Helper::FAKE_USER_EMAIL;
+            $username    = wc_create_new_customer_username( $email );
+            $customer_id = wc_create_new_customer( $email, $username, null, [
+                'first_name'    => 'Anonymous Vipps MobilePay Customer',
+                'user_nicename' => __( 'Anonymous Vipps MobilePay Customer', 'woo-vipps' ),
+            ] );
 
-			update_option( WC_Vipps_Recurring_Helper::OPTION_ANONYMOUS_SYSTEM_CUSTOMER_ID, $customer_id );
-		}
+            update_option( WC_Vipps_Recurring_Helper::OPTION_ANONYMOUS_SYSTEM_CUSTOMER_ID, $customer_id );
+        }
 
-		return new WC_Customer( $customer_id );
-	}
+        return new WC_Customer( $customer_id );
+    }
 
-	public function create_partial_subscription_groups_from_order( WC_Order $order ): array {
-		$subscription_groups = [];
+    public function create_partial_subscription_groups_from_order( WC_Order $order ): array {
+        $subscription_groups = [];
 
-		// Group the order items into subscription groups.
-		foreach ( $order->get_items() as $item ) {
-			$product = $item->get_product();
+        // Group the order items into subscription groups.
+        foreach ( $order->get_items() as $item ) {
+            $product = $item->get_product();
 
-			if ( ! WC_Subscriptions_Product::is_subscription( $product ) ) {
-				continue;
-			}
+            if ( ! WC_Subscriptions_Product::is_subscription( $product ) ) {
+                continue;
+            }
 
-			$subscription_groups[ wcs_get_subscription_item_grouping_key( $item ) ][] = $item;
-		}
+            $subscription_groups[ wcs_get_subscription_item_grouping_key( $item ) ][] = $item;
+        }
 
-		return $subscription_groups;
-	}
+        return $subscription_groups;
+    }
 
-	/**
-	 * Based on WC_REST_Subscriptions_Controller::create_subscriptions_from_order
-	 *
-	 * @throws Exception
-	 */
-	public function create_partial_subscriptions_from_order( WC_Order $order ) {
-		$order_id = WC_Vipps_Recurring_Helper::get_id( $order );
+    /**
+     * Based on WC_REST_Subscriptions_Controller::create_subscriptions_from_order
+     *
+     * @throws Exception
+     */
+    public function create_partial_subscriptions_from_order( WC_Order $order ) {
+        $order_id = WC_Vipps_Recurring_Helper::get_id( $order );
 
-		if ( ! $order->get_customer_id() ) {
-			return false;
-		}
+        if ( ! $order->get_customer_id() ) {
+            return false;
+        }
 
-		if ( wcs_order_contains_subscription( $order, 'any' ) ) {
-			return false;
-		}
+        if ( wcs_order_contains_subscription( $order, 'any' ) ) {
+            return false;
+        }
 
-		$subscriptions       = [];
-		$subscription_groups = $this->create_partial_subscription_groups_from_order( $order );
+        $subscriptions       = [];
+        $subscription_groups = $this->create_partial_subscription_groups_from_order( $order );
 
-		if ( empty( $subscription_groups ) ) {
-			return false;
-		}
+        if ( empty( $subscription_groups ) ) {
+            return false;
+        }
 
-		foreach ( $subscription_groups as $items ) {
-			// Get the first item in the group to use as the base for the subscription.
-			$product = $items[0]->get_product();
+        foreach ( $subscription_groups as $items ) {
+            // Get the first item in the group to use as the base for the subscription.
+            $product = $items[0]->get_product();
 
-			$start_date   = wcs_get_datetime_utc_string( $order->get_date_created( 'edit' ) );
-			$subscription = wcs_create_subscription( [
-				'order_id'         => $order_id,
-				'created_via'      => $order->get_created_via( 'edit' ),
-				'start_date'       => $start_date,
-				'status'           => $order->is_paid() ? 'active' : 'pending',
-				'billing_period'   => WC_Subscriptions_Product::get_period( $product ),
-				'billing_interval' => WC_Subscriptions_Product::get_interval( $product ),
-				'customer_note'    => $order->get_customer_note(),
-			] );
+            $start_date   = wcs_get_datetime_utc_string( $order->get_date_created( 'edit' ) );
+            $subscription = wcs_create_subscription( [
+                'order_id'         => $order_id,
+                'created_via'      => $order->get_created_via( 'edit' ),
+                'start_date'       => $start_date,
+                'status'           => $order->is_paid() ? 'active' : 'pending',
+                'billing_period'   => WC_Subscriptions_Product::get_period( $product ),
+                'billing_interval' => WC_Subscriptions_Product::get_interval( $product ),
+                'customer_note'    => $order->get_customer_note(),
+            ] );
 
-			if ( is_wp_error( $subscription ) ) {
-				throw new Exception( $subscription->get_error_message() );
-			}
+            if ( is_wp_error( $subscription ) ) {
+                throw new Exception( $subscription->get_error_message() );
+            }
 
-			wcs_copy_order_address( $order, $subscription );
+            wcs_copy_order_address( $order, $subscription );
 
-			$subscription->update_dates( [
-				'trial_end'    => WC_Subscriptions_Product::get_trial_expiration_date( $product, $start_date ),
-				'next_payment' => WC_Subscriptions_Product::get_first_renewal_payment_date( $product, $start_date ),
-				'end'          => WC_Subscriptions_Product::get_expiration_date( $product, $start_date ),
-			] );
+            $subscription->update_dates( [
+                'trial_end'    => WC_Subscriptions_Product::get_trial_expiration_date( $product, $start_date ),
+                'next_payment' => WC_Subscriptions_Product::get_first_renewal_payment_date( $product, $start_date ),
+                'end'          => WC_Subscriptions_Product::get_expiration_date( $product, $start_date ),
+            ] );
 
-			$subscription->set_payment_method( $order->get_payment_method() );
+            $subscription->set_payment_method( $order->get_payment_method() );
 
-			wcs_copy_order_meta( $order, $subscription, 'subscription' );
+            wcs_copy_order_meta( $order, $subscription, 'subscription' );
 
-			// Add items.
-			$subscription_needs_shipping = false;
-			foreach ( $items as $item ) {
-				// Create order line item.
-				$item_id = wc_add_order_item(
-					$subscription->get_id(),
-					[
-						'order_item_name' => $item->get_name(),
-						'order_item_type' => $item->get_type(),
-					]
-				);
+            // Add items.
+            $subscription_needs_shipping = false;
+            foreach ( $items as $item ) {
+                // Create order line item.
+                $item_id = wc_add_order_item(
+                    $subscription->get_id(),
+                    [
+                        'order_item_name' => $item->get_name(),
+                        'order_item_type' => $item->get_type(),
+                    ]
+                );
 
-				$subscription_item = $subscription->get_item( $item_id );
+                $subscription_item = $subscription->get_item( $item_id );
 
-				wcs_copy_order_item( $item, $subscription_item );
+                wcs_copy_order_item( $item, $subscription_item );
 
-				// Don't include sign-up fees or $0 trial periods when setting the subscriptions item totals.
-				wcs_set_recurring_item_total( $subscription_item );
+                // Don't include sign-up fees or $0 trial periods when setting the subscriptions item totals.
+                wcs_set_recurring_item_total( $subscription_item );
 
-				$subscription_item->save();
+                $subscription_item->save();
 
-				// Check if this subscription will need shipping.
-				if ( ! $subscription_needs_shipping ) {
-					$product = $item->get_product();
+                // Check if this subscription will need shipping.
+                if ( ! $subscription_needs_shipping ) {
+                    $product = $item->get_product();
 
-					if ( $product ) {
-						$subscription_needs_shipping = $product->needs_shipping() && ! WC_Subscriptions_Product::needs_one_time_shipping( $product );
-					}
-				}
-			}
+                    if ( $product ) {
+                        $subscription_needs_shipping = $product->needs_shipping() && ! WC_Subscriptions_Product::needs_one_time_shipping( $product );
+                    }
+                }
+            }
 
-			// Add coupons.
-			foreach ( $order->get_coupons() as $coupon_item ) {
-				$coupon = new WC_Coupon( $coupon_item->get_code() );
+            // Add coupons.
+            foreach ( $order->get_coupons() as $coupon_item ) {
+                $coupon = new WC_Coupon( $coupon_item->get_code() );
 
-				try {
-					// validate_subscription_coupon_for_order will throw an exception if the coupon cannot be applied to the subscription.
-					WC_Subscriptions_Coupon::validate_subscription_coupon_for_order( true, $coupon, $subscription );
+                try {
+                    // validate_subscription_coupon_for_order will throw an exception if the coupon cannot be applied to the subscription.
+                    WC_Subscriptions_Coupon::validate_subscription_coupon_for_order( true, $coupon, $subscription );
 
-					$subscription->apply_coupon( $coupon->get_code() );
-				} catch ( Exception $e ) {
-					// Do nothing. The coupon will not be applied to the subscription.
-				}
-			}
+                    $subscription->apply_coupon( $coupon->get_code() );
+                } catch ( Exception $e ) {
+                    // Do nothing. The coupon will not be applied to the subscription.
+                }
+            }
 
-			// Add shipping.
-			if ( $subscription_needs_shipping ) {
-				foreach ( $order->get_shipping_methods() as $shipping_item ) {
-					$rate = new WC_Shipping_Rate( $shipping_item->get_method_id(), $shipping_item->get_method_title(), $shipping_item->get_total(), $shipping_item->get_taxes(), $shipping_item->get_instance_id() );
+            // Add shipping.
+            if ( $subscription_needs_shipping ) {
+                foreach ( $order->get_shipping_methods() as $shipping_item ) {
+                    $rate = new WC_Shipping_Rate( $shipping_item->get_method_id(), $shipping_item->get_method_title(), $shipping_item->get_total(), $shipping_item->get_taxes(), $shipping_item->get_instance_id() );
 
-					$item = new WC_Order_Item_Shipping();
-					$item->set_order_id( $subscription->get_id() );
-					$item->set_shipping_rate( $rate );
+                    $item = new WC_Order_Item_Shipping();
+                    $item->set_order_id( $subscription->get_id() );
+                    $item->set_shipping_rate( $rate );
 
-					$subscription->add_item( $item );
-				}
-			}
+                    $subscription->add_item( $item );
+                }
+            }
 
-			// Add fees.
-			foreach ( $order->get_fees() as $fee_item ) {
-				if ( ! apply_filters( 'wcs_should_copy_fee_item_to_subscription', true, $fee_item, $subscription, $order ) ) {
-					continue;
-				}
+            // Add fees.
+            foreach ( $order->get_fees() as $fee_item ) {
+                if ( ! apply_filters( 'wcs_should_copy_fee_item_to_subscription', true, $fee_item, $subscription, $order ) ) {
+                    continue;
+                }
 
-				$item = new WC_Order_Item_Fee();
-				$item->set_props(
-					array(
-						'name'      => $fee_item->get_name(),
-						'tax_class' => $fee_item->get_tax_class(),
-						'amount'    => $fee_item->get_amount(),
-						'total'     => $fee_item->get_total(),
-						'total_tax' => $fee_item->get_total_tax(),
-						'taxes'     => $fee_item->get_taxes(),
-					)
-				);
+                $item = new WC_Order_Item_Fee();
+                $item->set_props(
+                    array(
+                        'name'      => $fee_item->get_name(),
+                        'tax_class' => $fee_item->get_tax_class(),
+                        'amount'    => $fee_item->get_amount(),
+                        'total'     => $fee_item->get_total(),
+                        'total_tax' => $fee_item->get_total_tax(),
+                        'taxes'     => $fee_item->get_taxes(),
+                    )
+                );
 
-				$subscription->add_item( $item );
-			}
+                $subscription->add_item( $item );
+            }
 
-			// Remove this action to avoid making an unnecessary API request
-			remove_action( 'woocommerce_order_after_calculate_totals', [
-				$this,
-				'update_agreement_price_in_app'
-			] );
+            // Remove this action to avoid making an unnecessary API request
+            remove_action( 'woocommerce_order_after_calculate_totals', [
+                $this,
+                'update_agreement_price_in_app'
+            ] );
 
-			$subscription->calculate_totals();
-			$subscription->save();
+            $subscription->calculate_totals();
+            $subscription->save();
 
-			$subscriptions[] = wcs_get_subscription( $subscription->get_id() );
-		}
+            $subscriptions[] = wcs_get_subscription( $subscription->get_id() );
+        }
 
-		return $subscriptions;
-	}
+        return $subscriptions;
+    }
 
-	public function maybe_delete_order_later( $order_id ) {
-		if ( $this->get_option( 'checkout_cleanup_abandoned_orders' ) !== 'yes' ) {
-			return;
-		}
+    public function maybe_delete_order_later( $order_id ) {
+        if ( $this->get_option( 'checkout_cleanup_abandoned_orders' ) !== 'yes' ) {
+            return;
+        }
 
-		if ( ! wp_next_scheduled( 'woocommerce_vipps_recurring_delete_pending_order', [ $order_id ] ) ) {
-			wp_schedule_single_event( time() + 3600, 'woocommerce_vipps_recurring_delete_pending_order', [ $order_id ] );
-		}
-	}
+        if ( ! wp_next_scheduled( 'woocommerce_vipps_recurring_delete_pending_order', [ $order_id ] ) ) {
+            wp_schedule_single_event( time() + 3600, 'woocommerce_vipps_recurring_delete_pending_order', [ $order_id ] );
+        }
+    }
 
-	public function maybe_delete_order( $order_id ): bool {
-		$order = wc_get_order( $order_id );
-		if ( ! $order ) {
-			return false;
-		}
+    public function maybe_delete_order( $order_id ): bool {
+        $order = wc_get_order( $order_id );
+        if ( ! $order ) {
+            return false;
+        }
 
-		if ( $this->id !== $order->get_payment_method() ) {
-			return false;
-		}
+        if ( $this->id !== $order->get_payment_method() ) {
+            return false;
+        }
 
-		$express = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS );
-		if ( ! $express ) {
-			return false;
-		}
+        $express = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_IS_EXPRESS );
+        if ( ! $express ) {
+            return false;
+        }
 
-		$empty_email = $order->get_billing_email() === WC_Vipps_Recurring_Helper::FAKE_USER_EMAIL || ! $order->get_billing_email();
-		if ( ! $empty_email ) {
-			return false;
-		}
+        $empty_email = $order->get_billing_email() === WC_Vipps_Recurring_Helper::FAKE_USER_EMAIL || ! $order->get_billing_email();
+        if ( ! $empty_email ) {
+            return false;
+        }
 
-		if ( $this->get_option( 'checkout_cleanup_abandoned_orders' ) !== 'yes' ) {
-			return false;
-		}
+        if ( $this->get_option( 'checkout_cleanup_abandoned_orders' ) !== 'yes' ) {
+            return false;
+        }
 
-		WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_MARKED_FOR_DELETION, 1 );
-		$order->save();
+        WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_MARKED_FOR_DELETION, 1 );
+        $order->save();
 
-		return true;
-	}
+        return true;
+    }
 }

--- a/recurring/includes/wc-gateway-vipps-recurring.php
+++ b/recurring/includes/wc-gateway-vipps-recurring.php
@@ -376,9 +376,9 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 	public function use_high_performance_order_storage(): bool {
 		if ( $this->use_high_performance_order_storage === null ) {
 			$this->use_high_performance_order_storage = function_exists( 'wc_get_container' ) &&  // 4.4.0
-														function_exists( 'wc_get_page_screen_id' ) && // Exists in the HPOS update
-														class_exists( "Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController" ) &&
-														wc_get_container()->get( Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
+			                                            function_exists( 'wc_get_page_screen_id' ) && // Exists in the HPOS update
+			                                            class_exists( "Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController" ) &&
+			                                            wc_get_container()->get( Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
 		}
 
 		return $this->use_high_performance_order_storage;
@@ -565,7 +565,7 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 		WC_Vipps_Recurring_Helper::set_latest_api_status_for_order( $order, $charge->status );
 
 		$initial        = empty( WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL ) )
-						  && ! wcs_order_contains_renewal( $order );
+		                  && ! wcs_order_contains_renewal( $order );
 		$pending_charge = $initial ? 1 : (int) WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING );
 		$did_fail       = WC_Vipps_Recurring_Helper::is_charge_failed_for_order( $order );
 
@@ -584,8 +584,8 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 		// If the brand is MobilePay, we should capture the payment now if it is not already captured.
 		// This is because MobilePay auto-releases and refunds payments after 7 days. Vipps will keep a reservation for a lot longer.
 		if ( $this->brand === WC_Vipps_Recurring_Helper::BRAND_MOBILEPAY
-			 && ! $is_captured
-			 && $this->auto_capture_mobilepay ) {
+		     && ! $is_captured
+		     && $this->auto_capture_mobilepay ) {
 			$order->save();
 
 			if ( $this->maybe_capture_payment( $order_id ) ) {
@@ -732,7 +732,7 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 		// status: RESERVED
 		// not auto captured, so we need to put the order status to `$this->default_reserved_charge_status`
 		if ( ! $transaction_id && $charge->status === WC_Vipps_Charge::STATUS_RESERVED
-			 && ! wcs_order_contains_renewal( $order ) ) {
+		     && ! wcs_order_contains_renewal( $order ) ) {
 			WC_Vipps_Recurring_Helper::set_transaction_id_for_order( $order, $charge->id );
 
 			$message = __( 'Waiting for you to capture the payment', 'woo-vipps' );
@@ -743,11 +743,11 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 		// status: DUE or PENDING
 		// when DUE, we need to check that it becomes another status in a cron
 		$initial = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL )
-				   && ! wcs_order_contains_renewal( $order );
+		           && ! wcs_order_contains_renewal( $order );
 
 		if ( ! $initial && ! $transaction_id && ( $charge->status === WC_Vipps_Charge::STATUS_DUE
-												  || ( $charge->status === WC_Vipps_Charge::STATUS_PENDING
-													   && wcs_order_contains_renewal( $order ) ) ) ) {
+		                                          || ( $charge->status === WC_Vipps_Charge::STATUS_PENDING
+		                                               && wcs_order_contains_renewal( $order ) ) ) ) {
 			WC_Vipps_Recurring_Helper::set_transaction_id_for_order( $order, $charge->id );
 
 			WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_CAPTURED, true );
@@ -786,8 +786,8 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 
 		// if status was FAILED, but no longer is
 		if ( $charge->status !== WC_Vipps_Charge::STATUS_FAILED
-			 && WC_Vipps_Recurring_Helper::is_charge_failed_for_order( $order )
-			 && in_array( $charge->status, [ WC_Vipps_Charge::STATUS_PROCESSING, 'DUE', 'PENDING' ], true ) ) {
+		     && WC_Vipps_Recurring_Helper::is_charge_failed_for_order( $order )
+		     && in_array( $charge->status, [ WC_Vipps_Charge::STATUS_PROCESSING, 'DUE', 'PENDING' ], true ) ) {
 			WC_Vipps_Recurring_Helper::set_order_charge_not_failed( $order, $charge->id );
 		}
 
@@ -1525,9 +1525,9 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 		$is_failed_renewal_order = wcs_cart_contains_failed_renewal_order_payment() !== false;
 
 		if ( ! $is_gateway_change
-			 && ! $is_failed_renewal_order
-			 && ! wcs_order_contains_subscription( $order )
-			 && ! wcs_order_contains_early_renewal( $order ) ) {
+		     && ! $is_failed_renewal_order
+		     && ! wcs_order_contains_subscription( $order )
+		     && ! wcs_order_contains_early_renewal( $order ) ) {
 			return [
 				'result'   => 'fail',
 				'redirect' => ''
@@ -1785,23 +1785,23 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 
 		ob_start();
 		?>
-		<tr valign="top">
-			<th
-				scope="row"
-				class="titledesc"
-			>
-				<label
-					for="<?php echo esc_attr( $field_key ); ?>"><?php echo wp_kses_post( $data['title'] ); ?><?php echo $this->get_tooltip_html( $data ); // WPCS: XSS ok. ?></label>
-			</th>
-			<td class="forminp">
-				<fieldset>
-					<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span>
-					</legend>
+        <tr valign="top">
+            <th
+                    scope="row"
+                    class="titledesc"
+            >
+                <label
+                        for="<?php echo esc_attr( $field_key ); ?>"><?php echo wp_kses_post( $data['title'] ); ?><?php echo $this->get_tooltip_html( $data ); // WPCS: XSS ok. ?></label>
+            </th>
+            <td class="forminp">
+                <fieldset>
+                    <legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span>
+                    </legend>
 					<?php echo $dropdown_pages; ?>
 					<?php echo $this->get_description_html( $data ); // WPCS: XSS ok. ?>
-				</fieldset>
-			</td>
-		</tr>
+                </fieldset>
+            </td>
+        </tr>
 		<?php
 
 		return ob_get_clean();
@@ -1875,7 +1875,7 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 
 	public function process_admin_options(): bool {
 		$saved = parent::process_admin_options();
-                delete_transient('_vipps_keyset'); // Same transient as for the payment api IOK 2024-12-03
+		delete_transient( '_vipps_keyset' ); // Same transient as for the payment api IOK 2024-12-03
 
 		$this->init_form_fields();
 
@@ -2208,8 +2208,8 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 	 */
 	public function prevent_backwards_transition_on_completed_order( $status, $order_id, $order ): ?string {
 		if ( $status === 'processing'
-			 && $order->has_status( 'completed' )
-			 && $order->get_payment_method() === $this->id ) {
+		     && $order->has_status( 'completed' )
+		     && $order->get_payment_method() === $this->id ) {
 			return 'completed';
 		}
 
@@ -2483,19 +2483,24 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 			if ( empty( $order_id ) ) {
 				$charge_id = $webhook_data['chargeId'];
 
-				$options = [
+				$orders = wc_get_orders( [
 					'limit'          => 1,
-					'type'           => 'shop_order',
-					'meta_key'       => WC_Vipps_Recurring_Helper::META_CHARGE_ID,
-					'meta_compare'   => '=',
-					'meta_value'     => $charge_id,
-					'return'         => 'ids',
+					'meta_query'     => [
+						[
+							'key'     => WC_Vipps_Recurring_Helper::META_CHARGE_ID,
+							'compare' => '=',
+							'value'   => $charge_id
+						]
+					],
 					'payment_method' => $this->id,
 					'order_by'       => 'post_date'
-				];
+				] );
 
-				$order_ids = wc_get_orders( $options );
-				$order_id  = array_pop( $order_ids );
+				$order = array_pop( $orders );
+
+				if ( $order ) {
+					$order_id = WC_Vipps_Recurring_Helper::get_id( $order );
+				}
 			}
 
 			if ( empty( $charge_id ) ) {
@@ -2551,8 +2556,8 @@ class WC_Gateway_Vipps_Recurring extends WC_Payment_Gateway {
 
 	public function checkout_is_available() {
 		if ( ! $this->checkout_enabled
-			 || ! $this->is_available()
-			 || ! $this->cart_supports_checkout() ) {
+		     || ! $this->is_available()
+		     || ! $this->cart_supports_checkout() ) {
 			return false;
 		}
 

--- a/recurring/includes/wc-vipps-recurring-checkout.php
+++ b/recurring/includes/wc-vipps-recurring-checkout.php
@@ -486,7 +486,6 @@ class WC_Vipps_Recurring_Checkout {
 			return;
 		}
 
-		WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Polling checkout from check_order_status", $order_id ) );
 		$session = $this->gateway()->api->checkout_poll( $session['pollingUrl'] );
 
 		$this->handle_payment( $order, $session );

--- a/recurring/includes/wc-vipps-recurring-checkout.php
+++ b/recurring/includes/wc-vipps-recurring-checkout.php
@@ -3,1148 +3,1148 @@
 defined( 'ABSPATH' ) || exit;
 
 class WC_Vipps_Recurring_Checkout {
-	private static ?WC_Vipps_Recurring_Checkout $instance = null;
-
-	private ?WC_Gateway_Vipps_Recurring $gateway = null;
-
-	/**
-	 * Returns the *Singleton* instance of this class.
-	 *
-	 * @return WC_Vipps_Recurring_Checkout The *Singleton* instance.
-	 */
-	public static function get_instance(): WC_Vipps_Recurring_Checkout {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
-	}
-
-	public static function register_hooks(): void {
-		$instance = WC_Vipps_Recurring_Checkout::get_instance();
-		add_action( 'init', [ $instance, 'init' ] );
-		// Higher priority than the single payments Vipps plugin
-		add_filter( 'woocommerce_get_checkout_page_id', [ $instance, 'woocommerce_get_checkout_page_id' ], 20 );
-		add_action( 'template_redirect', [ $instance, 'template_redirect' ] );
-
-		if ( is_admin() ) {
-			add_action( 'admin_init', [ $instance, 'admin_init' ] );
-		}
-	}
-
-	public function gateway(): ?WC_Gateway_Vipps_Recurring {
-		if ( $this->gateway ) {
-			return $this->gateway;
-		}
-
-		$this->gateway = WC_Vipps_Recurring::get_instance()->gateway();
-
-		return $this->gateway;
-	}
-
-	public function maybe_load_cart(): void {
-		if ( version_compare( WC_VERSION, '3.6.0', '>=' ) && WC()->is_rest_api_request() ) {
-			if ( empty( $_SERVER['REQUEST_URI'] ) ) {
-				return;
-			}
-
-			$rest_prefix = WC_Vipps_Recurring_Checkout_Rest_Api::$api_namespace;
-			$req_uri     = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
-
-			$is_my_endpoint = ( false !== strpos( $req_uri, $rest_prefix ) );
-
-			if ( ! $is_my_endpoint ) {
-				return;
-			}
-
-			require_once WC_ABSPATH . 'includes/wc-cart-functions.php';
-			require_once WC_ABSPATH . 'includes/wc-notice-functions.php';
-
-			if ( null === WC()->session ) {
-				$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-
-				// Prefix session class with global namespace if not already namespaced
-				if ( false === strpos( $session_class, '\\' ) ) {
-					$session_class = '\\' . $session_class;
-				}
-
-				WC()->session = new $session_class();
-				WC()->session->init();
-			}
-
-			/**
-			 * For logged in customers, pull data from their account rather than the
-			 * session which may contain incomplete data.
-			 */
-			if ( is_null( WC()->customer ) ) {
-				if ( is_user_logged_in() ) {
-					WC()->customer = new WC_Customer( get_current_user_id() );
-				} else {
-					WC()->customer = new WC_Customer( get_current_user_id(), true );
-				}
-
-				// Customer should be saved during shutdown.
-				add_action( 'shutdown', array( WC()->customer, 'save' ), 10 );
-			}
-
-			// Load Cart.
-			if ( null === WC()->cart ) {
-				WC()->cart = new WC_Cart();
-			}
-		}
-	}
-
-	public function init(): void {
-		require_once __DIR__ . '/wc-vipps-recurring-checkout-rest-api.php';
-		WC_Vipps_Recurring_Checkout_Rest_Api::get_instance();
-
-		add_action( 'wp_loaded', [ $this, 'maybe_load_cart' ], 5 );
-
-		add_action( 'wp_loaded', [ $this, 'register_scripts' ] );
-
-		// Prevent previews and prefetches of the Vipps Checkout page starting and creating orders
-		add_action( 'wp_head', [ $this, 'wp_head' ] );
-
-		// The Vipps MobilePay Checkout feature which overrides the normal checkout process uses a shortcode
-		add_shortcode( 'vipps_recurring_checkout', [ $this, 'shortcode' ] );
-
-		add_action( 'wc_vipps_recurring_before_cron_check_order_status', [ $this, 'check_order_status' ] );
-		add_action( 'wc_vipps_recurring_before_rest_api_check_order_status', [ $this, 'check_order_status' ] );
-
-		// For Checkout, we need to know any time and as soon as the cart changes, so fold all the events into a single one
-		add_action( 'woocommerce_add_to_cart', function () {
-			do_action( 'vipps_recurring_cart_changed', 'woocommerce_add_to_cart' );
-		}, 10, 0 );
-
-		// Cart coupon applied
-		add_action( 'woocommerce_applied_coupon', function () {
-			do_action( 'vipps_recurring_cart_changed', 'woocommerce_applied_coupon' );
-		}, 10, 0 );
-
-		// Cart emptied
-		add_action( 'woocommerce_cart_emptied', function () {
-			do_action( 'vipps_recurring_cart_changed', 'woocommerce_cart_emptied' );
-		}, 10, 0 );
-
-		// After updating quantities
-		add_action( 'woocommerce_after_cart_item_quantity_update', function () {
-			do_action( 'vipps_recurring_cart_changed', 'woocommerce_after_cart_item_quantity_update' );
-		}, 10, 0 );
-
-		// Blocks and ajax
-		add_action( 'woocommerce_cart_item_removed', function () {
-			do_action( 'vipps_recurring_cart_changed', 'woocommerce_cart_item_removed' );
-		}, 10, 0 );
-
-		// Restore deleted entry
-		add_action( 'woocommerce_cart_item_restored', function () {
-			do_action( 'vipps_recurring_cart_changed', 'woocommerce_cart_item_restored' );
-		}, 10, 0 );
-
-		// Normal cart form update
-		add_filter( 'woocommerce_update_cart_action_cart_updated', function ( $updated ) {
-			do_action( 'vipps_recurring_cart_changed', 'woocommerce_update_cart_action_cart_updated' );
-
-			return $updated;
-		} );
-
-		// Then handle the actual cart change
-		add_action( 'vipps_recurring_cart_changed', [ $this, 'cart_changed' ] );
-
-		add_action( 'wc_vipps_recurring_checkout_callback', [ $this, 'handle_callback' ], 10, 2 );
-
-		// Handle cancelled orders
-		add_action( 'wc_vipps_recurring_check_charge_status_no_agreement', [ $this, 'maybe_cancel_initial_order' ] );
-
-		add_filter( 'wcs_user_has_subscription', [ $this, 'user_has_subscription' ], 10, 4 );
-	}
-
-	public function admin_init(): void {
-		// Checkout page
-		add_filter( 'woocommerce_settings_pages', array( $this, 'woocommerce_settings_pages' ) );
-	}
-
-	/**
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 */
-	public function maybe_create_session(): array {
-		$redirect_url = null;
-		$token        = null;
-		$url          = null;
-
-		$session = WC_Vipps_Recurring_Checkout::get_instance()->current_pending_session();
-
-		if ( isset( $session['redirect_url'] ) ) {
-			$redirect_url = $session['redirect_url'];
-		}
-
-		if ( isset( $session['session']['token'] ) ) {
-			$token = $session['session']['token'];
-			$src   = $session['session']['checkoutFrontendUrl'];
-			$url   = $src;
-		}
-
-		if ( $url ) {
-			$pending_order_id = WC_Vipps_Recurring_Helper::get_checkout_pending_order_id();
-
-			return [
-				'success'      => true,
-				'src'          => $url,
-				'redirect_url' => $redirect_url,
-				'token'        => $token,
-				'order_id'     => $pending_order_id
-			];
-		}
-
-		$session = null;
-
-		try {
-			$partial_order_id = WC_Gateway_Vipps_Recurring::get_instance()->create_partial_order( true );
-
-			$order      = wc_get_order( $partial_order_id );
-			$auth_token = WC_Gateway_Vipps_Recurring::get_instance()->api->generate_idempotency_key();
-
-			$order->update_meta_data( WC_Vipps_Recurring_Helper::META_ORDER_EXPRESS_AUTH_TOKEN, $auth_token );
-			$order->save();
-
-			WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_CHECKOUT_PENDING_ORDER_ID, $partial_order_id );
-			WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_ORDER_EXPRESS_AUTH_TOKEN, $auth_token );
-
-			do_action( 'wc_vipps_recurring_checkout_order_created', $order );
-		} catch ( Exception $exception ) {
-			return [
-				'success'      => false,
-				'msg'          => $exception->getMessage(),
-				'src'          => null,
-				'redirect_url' => null,
-				'order_id'     => 0
-			];
-		}
-
-		$order = wc_get_order( $partial_order_id );
-
-		$session_orders = WC()->session->get( WC_Vipps_Recurring_Helper::SESSION_ORDERS );
-		if ( ! $session_orders ) {
-			$session_orders = [];
-		}
-
-		$session_orders[ $partial_order_id ] = 1;
-		WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_PENDING_ORDER_ID, $partial_order_id );
-		WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_ORDERS, $session_orders );
-
-		$customer_id = get_current_user_id();
-		if ( $customer_id ) {
-			$customer = new WC_Customer( $customer_id );
-		} else {
-			$customer = WC()->customer;
-		}
-
-		if ( $customer ) {
-			$customer_info['email']         = $customer->get_billing_email();
-			$customer_info['firstName']     = $customer->get_billing_first_name();
-			$customer_info['lastName']      = $customer->get_billing_last_name();
-			$customer_info['streetAddress'] = $customer->get_billing_address_1();
-			$address2                       = trim( $customer->get_billing_address_2() );
-
-			if ( ! empty( $address2 ) ) {
-				$customer_info['streetAddress'] = $customer_info['streetAddress'] . ", " . $address2;
-			}
-			$customer_info['city']       = $customer->get_billing_city();
-			$customer_info['postalCode'] = $customer->get_billing_postcode();
-			$customer_info['country']    = $customer->get_billing_country();
-
-			// Currently Vipps requires all phone numbers to have area codes and NO +. We can't guarantee that at all, but try for Norway
-			$normalized_phone_number = WC_Vipps_Recurring_Helper::normalize_phone_number( $customer->get_billing_phone(), $customer_info['country'] );
-			if ( $normalized_phone_number ) {
-				$customer_info['phoneNumber'] = $normalized_phone_number;
-			}
-		}
-
-		$keys = [ 'firstName', 'lastName', 'streetAddress', 'postalCode', 'country', 'phoneNumber' ];
-		foreach ( $keys as $k ) {
-			if ( empty( $customer_info[ $k ] ) ) {
-				$customer_info = [];
-				break;
-			}
-		}
-		$customer_info = apply_filters( 'wc_vipps_recurring_customer_info', $customer_info, $order );
-
-		// todo: throw an error if we try to purchase a product with a location based shipping method?
-		try {
-			$checkout = WC_Vipps_Recurring_Checkout::get_instance();
-			$gateway  = $checkout->gateway();
-
-			$order_prefix = $gateway->order_prefix;
-
-			// hack - fake "Anonymous Vipps/MobilePay User"
-			$fake_user = false;
-			if ( ! $order->get_customer_id( 'edit' ) ) {
-				$fake_user = true;
-
-				$order->set_customer_id( $this->gateway()->create_or_get_anonymous_system_customer()->get_id() );
-				$order->save();
-			}
-
-			$subscriptions = $gateway->create_partial_subscriptions_from_order( $order );
-
-			// reset hack
-			if ( $fake_user ) {
-				$order->set_customer_id( 0 );
-				$order->save();
-			}
-
-			$subscription = array_pop( $subscriptions );
-
-			// Remove this action to avoid making an unnecessary API request
-			remove_action( 'woocommerce_order_after_calculate_totals', [
-				$this->gateway(),
-				'update_agreement_price_in_app'
-			] );
-
-			$subscription->calculate_totals();
-			$subscription->save();
-
-			$agreement = $gateway->create_vipps_agreement_from_order( $order, $subscription );
-
-			$checkout_subscription = ( new WC_Vipps_Checkout_Session_Subscription() )
-				->set_amount(
-					( new WC_Vipps_Checkout_Session_Amount() )
-						->set_value( $agreement->pricing->amount )
-						->set_currency( $agreement->pricing->currency )
-				)
-				->set_product_name( $agreement->product_name )
-				->set_interval( $agreement->interval )
-				->set_merchant_agreement_url( $agreement->merchant_agreement_url );
-
-			if ( $agreement->campaign ) {
-				$checkout_subscription = $checkout_subscription->set_campaign( $agreement->campaign );
-			}
-
-			if ( $agreement->product_description ) {
-				$checkout_subscription = $checkout_subscription->set_product_description( $agreement->product_description );
-			}
-
-			$customer = new WC_Vipps_Checkout_Session_Customer( $customer_info );
-
-			// Create a checkout session dto
-			$checkout_session = ( new WC_Vipps_Checkout_Session() )
-				->set_type( WC_Vipps_Checkout_Session::TYPE_SUBSCRIPTION )
-				->set_subscription( $checkout_subscription )
-				->set_merchant_info(
-					( new WC_Vipps_Checkout_Session_Merchant_Info() )
-						->set_callback_url( $gateway->webhook_callback_url() )
-						->set_return_url( $agreement->merchant_redirect_url )
-						->set_callback_authorization_token( $auth_token )
-				)
-				->set_prefill_customer( $customer )
-				->set_configuration(
-					( new WC_Vipps_Checkout_Session_Configuration() )
-						->set_user_flow( WC_Vipps_Checkout_Session_Configuration::USER_FLOW_WEB_REDIRECT )
-						->set_customer_interaction( WC_Vipps_Checkout_Session_Configuration::CUSTOMER_INTERACTION_NOT_PRESENT )
-						->set_elements( WC_Vipps_Checkout_Session_Configuration::ELEMENTS_FULL )
-						->set_require_user_info( empty( $customer->email ) )
-						->set_show_order_summary( true )
-				);
-
-			if ( $agreement->initial_charge ) {
-				$reference = WC_Vipps_Recurring_Helper::generate_vipps_order_id( $order, $order_prefix );
-
-				$checkout_transaction = ( new WC_Vipps_Checkout_Session_Transaction() )
-					->set_reference( $reference )
-					->set_amount(
-						( new WC_Vipps_Checkout_Session_Amount() )
-							->set_value( $agreement->initial_charge->amount )
-							->set_currency( $agreement->pricing->currency )
-					)
-					->set_order_summary( $checkout->make_order_summary( $order ) );
-
-				if ( $agreement->initial_charge->description ) {
-					$checkout_transaction = $checkout_transaction->set_payment_description( $agreement->initial_charge->description );
-				}
-
-				$checkout_session = $checkout_session->set_transaction( $checkout_transaction );
-
-				WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $reference );
-			}
-
-			$checkout_session = apply_filters( 'wc_vipps_recurring_checkout_session', $checkout_session, $order );
-
-			$session = WC_Gateway_Vipps_Recurring::get_instance()->api->checkout_initiate( $checkout_session );
-
-			$order = wc_get_order( $partial_order_id );
-			WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, true );
-			WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL, true );
-			WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION, $session->to_array() );
-
-			$session_poll = WC_Gateway_Vipps_Recurring::get_instance()->api->checkout_poll( $session->polling_url );
-			WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION_ID, $session_poll['sessionId'] );
-
-			$order->add_order_note( __( 'Vipps/MobilePay recurring checkout payment initiated', 'woo-vipps' ) );
-			$order->add_order_note( __( 'Customer passed to Vipps/MobilePay checkout', 'woo-vipps' ) );
-			$order->save();
-
-			$token = $session->token;
-			$src   = $session->checkout_frontend_url;
-			$url   = $src;
-		} catch ( Exception $e ) {
-			WC_Vipps_Recurring_Logger::log( sprintf( "Could not initiate Vipps/MobilePay checkout session: %s", $e->getMessage() ) );
-
-			return [
-				'success'      => false,
-				'msg'          => $e->getMessage(),
-				'src'          => null,
-				'redirect_url' => null,
-				'order_id'     => $partial_order_id
-			];
-		}
-
-		if ( $url || $redirect_url ) {
-			return [
-				'success'      => true,
-				'msg'          => 'session started',
-				'src'          => $url,
-				'redirect_url' => $redirect_url,
-				'token'        => $token,
-				'order_id'     => $partial_order_id
-			];
-		}
-
-		return [
-			'success'      => false,
-			'msg'          => __( 'Could not start Vipps/MobilePay checkout session', 'woo-vipps' ),
-			'src'          => $url,
-			'redirect_url' => $redirect_url,
-			'order_id'     => $partial_order_id
-		];
-	}
-
-	public function maybe_login_checkout_user( int $order_id, ?string $key = null ): void {
-		if ( ! $key ) {
-			return;
-		}
-
-		$order = wc_get_order( $order_id );
-		if ( ! $order ) {
-			return;
-		}
-
-		$order_key_db = $order->get_order_key( 'code' );
-		if ( $order_key_db !== $key ) {
-			return;
-		}
-
-		// Attempt to log the user in
-		$session_auth_token = WC()->session->get( WC_Vipps_Recurring_Helper::SESSION_ORDER_EXPRESS_AUTH_TOKEN );
-		$order_auth_token   = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_EXPRESS_AUTH_TOKEN );
-
-		if ( $order_auth_token !== $session_auth_token ) {
-			return;
-		}
-
-		$user = $order->get_user();
-
-		wc_set_customer_auth_cookie( $user->ID );
-		WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_ORDER_EXPRESS_AUTH_TOKEN, null );
-	}
-
-	public function cart_changed( string $source ): void {
-		$pending_order_id = is_a( WC()->session, 'WC_Session' ) ? WC()->session->get( WC_Vipps_Recurring_Helper::SESSION_CHECKOUT_PENDING_ORDER_ID ) : false;
-		$order            = $pending_order_id ? wc_get_order( $pending_order_id ) : null;
-
-		if ( ! $order ) {
-			return;
-		}
-
-		WC_Vipps_Recurring_Logger::log( sprintf( "Checkout cart changed while session %d in progress, attempting to cancel. Source: %s", $order->get_id(), $source ) );
-		$this->abandon_checkout_order( $order );
-	}
-
-	/**
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 * @throws WC_Data_Exception
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 */
-	public function check_order_status( $order_id ): void {
-		$lock_name = "vipps_recurring_checkout_check_order_status_$order_id";
-		$lock      = get_transient( $lock_name );
-
-		if ( $lock ) {
-			return;
-		}
-
-		set_transient( $lock_name, uniqid( '', true ), 5 );
-
-		$order = wc_get_order( $order_id );
-
-		if ( ! WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_IS_CHECKOUT ) ) {
-			return;
-		}
-
-		$session = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION );
-		if ( ! is_array( $session ) ) {
-			return;
-		}
-
-		$session = $this->gateway()->api->checkout_poll( $session['pollingUrl'] );
-
-		$this->handle_payment( $order, $session );
-	}
-
-	public function woocommerce_settings_pages( $settings ) {
-		$checkout_enabled = get_option( WC_Vipps_Recurring_Helper::OPTION_CHECKOUT_ENABLED, false );
-		if ( ! $checkout_enabled ) {
-			return $settings;
-		}
-
-		// Find out where the end of the section advanced_page_options is
-		$i     = 0;
-		$count = count( $settings );
-
-		for ( ; $i < $count; $i ++ ) {
-			if ( $settings[ $i ]['type'] === 'sectionend' && $settings[ $i ]['id'] === 'advanced_page_options' ) {
-				break;
-			}
-		}
-
-		if ( $i < $count ) {
-			array_splice( $settings, $i, 0, [
-				[
-					'title'    => __( 'Vipps/MobilePay Recurring Checkout Page', 'woo-vipps' ),
-					'desc'     => __( 'This page is used for the alternative Vipps/MobilePay checkout page, which you can choose to use instead of the normal WooCommerce checkout page. ', 'woo-vipps' ) . sprintf( __( 'Page contents: [%1$s]', 'woocommerce' ), 'vipps_recurring_checkout' ),
-					'id'       => 'woocommerce_vipps_recurring_checkout_page_id',
-					'type'     => 'single_select_page_with_search',
-					'default'  => '',
-					'class'    => 'wc-page-search',
-					'css'      => 'min-width:300px;',
-					'args'     => [
-						'exclude' =>
-							[
-								wc_get_page_id( 'myaccount' ),
-							],
-					],
-					'desc_tip' => true,
-					'autoload' => false,
-				]
-			] );
-		}
-
-		return $settings;
-	}
-
-	public function woocommerce_get_checkout_page_id( $id ): int {
-		$checkout_enabled = get_option( WC_Vipps_Recurring_Helper::OPTION_CHECKOUT_ENABLED, false );
-
-		if ( ! $checkout_enabled ) {
-			return $id;
-		}
-
-		$checkout_id = $this->gateway()->checkout_is_available();
-		if ( $checkout_id ) {
-			return $checkout_id;
-		}
-
-		return $id;
-	}
-
-	public function template_redirect(): void {
-		global $post;
-
-		if ( $post && is_page() && has_shortcode( $post->post_content, 'vipps_recurring_checkout' ) ) {
-			add_filter( 'woocommerce_is_checkout', '__return_true' );
-
-			add_filter( 'body_class', function ( $classes ) {
-				$classes[] = 'vipps-recurring-checkout';
-				$classes[] = 'woocommerce-checkout'; // Required by Pixel Your Site
-
-				return apply_filters( 'wc_vipps_recurring_checkout_body_class', $classes );
-			} );
-
-			// Suppress the title for this page
-			$post_to_hide_title_for = $post->ID;
-			add_filter( 'the_title', function ( $title, $postid = 0 ) use ( $post_to_hide_title_for ) {
-				if ( ! is_admin() && $postid == $post_to_hide_title_for && is_singular() && in_the_loop() ) {
-					$title = "";
-				}
-
-				return $title;
-			}, 10, 2 );
-
-			wc_nocache_headers();
-		}
-	}
-
-	public function wp_head(): void {
-		// If we have a Vipps MobilePay Checkout page, stop iOS from giving previews of it that
-		// starts the session - iOS should use the visibility API of the browser for this, but it doesn't as of 2021-11-11
-		$checkout_id = wc_get_page_id( 'vipps_recurring_checkout' );
-		if ( $checkout_id ) {
-			$url = get_permalink( $checkout_id );
-			echo "<style> a[href=\"$url\"] { -webkit-touch-callout: none;  } </style>\n";
-		}
-	}
-
-	public function register_scripts(): void {
-		$sdk_url = 'https://checkout.vipps.no/vippsCheckoutSDK.js';
-		wp_register_script( 'woo-vipps-recurring-sdk', $sdk_url );
-
-		// Register our React component
-		wp_enqueue_style(
-			'woo-vipps-recurring-checkout',
-
-			WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/build/checkout.css', [],
-			filemtime( WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/checkout.css' )
-		);
-
-		$asset = require WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/checkout.asset.php';
-
-		wp_enqueue_script(
-			'woo-vipps-recurring-checkout',
-			WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/build/checkout.js',
-			array_merge( $asset['dependencies'], [ 'woo-vipps-recurring', 'woo-vipps-recurring-sdk' ] ),
-			filemtime( WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/checkout.js' ),
-			true
-		);
-	}
-
-	/**
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 */
-	public function shortcode() {
-		global $wp;
-
-		if ( is_admin() || wp_doing_ajax() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
-			return false;
-		}
-
-		// No point in expanding this unless we are actually doing the checkout. IOK 2021-09-03
-		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
-		add_filter( 'wc_vipps_recurring_is_vipps_checkout', '__return_true' );
-
-		if ( is_wc_endpoint_url( 'order-received' ) ) {
-			$order_id = absint( $wp->query_vars['order-received'] );
-			$this->maybe_login_checkout_user( $order_id, $_GET['key'] ?? null );
-		}
-
-		// Defer to the normal code for endpoints IOK 2022-12-09
-		if ( is_wc_endpoint_url( 'order-pay' ) || is_wc_endpoint_url( 'order-received' ) ) {
-			return do_shortcode( "[woocommerce_checkout]" );
-		}
-
-		if ( ! WC()->cart || WC()->cart->is_empty() ) {
-			$this->abandon_checkout_order( false );
-			ob_start();
-			wc_get_template( 'cart/cart-empty.php' );
-
-			return ob_get_clean();
-		}
-
-		// Previously registered, now enqueue this script which should then appear in the footer.
-		wp_enqueue_script( 'vipps-recurring-checkout' );
-
-		do_action( 'vipps_recurring_checkout_before_get_session' );
-
-		// Localize script with variables we need to reveal to the frontend
-		$data = $this->current_pending_session();
-		if ( empty( $data['session'] ) ) {
-			$data['session'] = $this->maybe_create_session();
-		}
-
-		wp_add_inline_script( 'woo-vipps-recurring-checkout', 'window.VippsRecurringCheckout = ' . wp_json_encode( $data ), 'before' );
-
-		return '<div id="vipps-mobilepay-recurring-checkout"></div>';
-	}
-
-	public function make_order_summary( $order ): WC_Vipps_Checkout_Session_Transaction_Order_Summary {
-		$order_lines = [];
-
-		$bottom_line = ( new WC_Vipps_Checkout_Session_Transaction_Order_Summary_Bottom_Line() )
-			->set_currency( $order->get_currency() )
-			->set_gift_card_amount( apply_filters( 'wc_vipps_recurring_order_gift_card_amount', 0, $order ) * 100 )
-			->set_tip_amount( apply_filters( 'wc_vipps_recurring_order_tip_amount', 0, $order ) * 100 )
-			->set_terminal_id( apply_filters( 'wc_vipps_recurring_order_terminal_id', 'woocommerce', $order ) )
-			->set_receipt_number( strval( WC_Vipps_Recurring_Helper::get_id( $order ) ) );
-
-		foreach ( $order->get_items() as $order_item ) {
-			$order_line      = [];
-			$product_id      = $order_item->get_product_id(); // sku can be tricky
-			$total_no_tax    = $order_item->get_total();
-			$tax             = $order_item->get_total_tax();
-			$total           = $tax + $total_no_tax;
-			$subtotal_no_tax = $order_item->get_subtotal();
-			$subtotal_tax    = $order_item->get_subtotal_tax();
-			$subtotal        = $subtotal_no_tax + $subtotal_tax;
-			$quantity        = $order_item->get_quantity();
-			$unit_price      = $subtotal / $quantity;
-
-			// Must do this to avoid rounding errors, since we get floats instead of money here :(
-			$discount = round( 100 * $subtotal ) - round( 100 * $total );
-			if ( $discount < 0 ) {
-				$discount = 0;
-			}
-
-			$product = wc_get_product( $product_id );
-			$url     = home_url( "/" );
-			if ( $product ) {
-				$url = get_permalink( $product_id );
-			}
-
-			if ( $subtotal_no_tax == 0 ) {
-				$tax_percentage = 0;
-			} else {
-				$tax_percentage = ( ( $subtotal - $subtotal_no_tax ) / $subtotal_no_tax ) * 100;
-			}
-			$tax_percentage = abs( round( $tax_percentage ) );
-
-			$unit_info                             = [];
-			$order_line['name']                    = $order_item->get_name();
-			$order_line['id']                      = strval( $product_id );
-			$order_line['totalAmount']             = round( $total * 100 );
-			$order_line['totalAmountExcludingTax'] = round( $total_no_tax * 100 );
-			$order_line['totalTaxAmount']          = round( $tax * 100 );
-			$order_line['taxRate']                 = round( $tax_percentage * 100 );
-
-			$unit_info['unitPrice']    = round( $unit_price * 100 );
-			$unit_info['quantity']     = strval( $quantity );
-			$unit_info['quantityUnit'] = 'PCS';
-			$order_line['unitInfo']    = $unit_info;
-			$order_line['discount']    = $discount;
-			$order_line['productUrl']  = $url;
-			$order_line['isShipping']  = false;
-
-			$order_lines[] = $order_line;
-		}
-
-		foreach ( $order->get_items( 'fee' ) as $order_item ) {
-			$order_line                            = [];
-			$total_no_tax                          = $order_item->get_total();
-			$tax                                   = $order_item->get_total_tax();
-			$total                                 = $tax + $total_no_tax;
-			$tax_percentage                        = ( ( $total - $total_no_tax ) / $total_no_tax ) * 100;
-			$tax_percentage                        = abs( round( $tax_percentage ) );
-			$order_line['name']                    = $order_item->get_name();
-			$order_line['id']                      = substr( sanitize_title( $order_line['name'] ), 0, 254 );
-			$order_line['totalAmount']             = round( $total * 100 );
-			$order_line['totalAmountExcludingTax'] = round( $total_no_tax * 100 );
-			$order_line['totalTaxAmount']          = round( $tax * 100 );
-			$order_line['discount']                = 0;
-			$order_line['taxRate']                 = round( $tax_percentage * 100 );
-
-			$order_lines[] = $order_line;
-		}
-
-		// Handle shipping
-		foreach ( $order->get_items( 'shipping' ) as $order_item ) {
-			$order_line         = [];
-			$order_line['name'] = $order_item->get_name();
-			$order_line['id']   = strval( $order_item->get_method_id() );
-			if ( method_exists( $order_item, 'get_instance_id' ) ) {
-				$order_line['id'] .= ":" . $order_item->get_instance_id();
-			}
-
-			$total_no_tax    = $order_item->get_total();
-			$tax             = $order_item->get_total_tax();
-			$total           = $tax + $total_no_tax;
-			$subtotal_no_tax = $total_no_tax;
-			$subtotal_tax    = $tax;
-			$subtotal        = $subtotal_no_tax + $subtotal_tax;
-
-			if ( $subtotal_no_tax == 0 ) {
-				$tax_percentage = 0;
-			} else {
-				$tax_percentage = ( ( $subtotal - $subtotal_no_tax ) / $subtotal_no_tax ) * 100;
-			}
-			$tax_percentage = abs( round( $tax_percentage ) );
-
-			$order_line['totalAmount']             = round( $total * 100 );
-			$order_line['totalAmountExcludingTax'] = round( $total_no_tax * 100 );
-			$order_line['totalTaxAmount']          = round( $tax * 100 );
-			$order_line['taxRate']                 = round( $tax_percentage * 100 );
-
-			$unit_info                 = [];
-			$unit_info['unitPrice']    = round( $total * 100 );
-			$unit_info['quantity']     = strval( 1 );
-			$unit_info['quantityUnit'] = 'PCS';
-
-			$order_line['unitInfo']   = $unit_info;
-			$discount                 = 0;
-			$order_line['discount']   = $discount;
-			$order_line['isShipping'] = true;
-
-			$order_lines[] = $order_line;
-		}
-
-		return ( new WC_Vipps_Checkout_Session_Transaction_Order_Summary() )
-			->set_order_lines( $order_lines )
-			->set_order_bottom_line( $bottom_line );
-	}
-
-	/**
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 */
-	public function current_pending_session(): array {
-		// If this is set, this is a currently pending order which is maybe still valid
-		$pending_order_id = WC_Vipps_Recurring_Helper::get_checkout_pending_order_id();
-		$order            = $pending_order_id ? wc_get_order( $pending_order_id ) : null;
-
-		# If we do have an order, we need to check if it is 'pending', and if not, we have to check its payment status
-		$payment_status = null;
-		$redirect       = null;
-
-		if ( $order ) {
-			if ( $order->get_status() === 'pending' ) {
-				$payment_status = 'INITIATED'; // Just assume this for now
-			} else {
-				$payment_status = $this->gateway()->check_charge_status( $pending_order_id, true ) ?? 'UNKNOWN';
-			}
-
-			if ( $payment_status === 'SUCCESS' ) {
-				$redirect = apply_filters( 'wc_vipps_recurring_merchant_redirect_url', WC_Vipps_Recurring_Helper::get_payment_redirect_url( $order ) );
-			}
-		}
-
-		if ( in_array( $payment_status, [ 'authorized', 'complete' ] ) ) {
-			$this->abandon_checkout_order( false );
-		} elseif ( $payment_status == 'cancelled' ) {
-			WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Vipps/MobilePay checkout session cancelled (pending session)", $order->get_id() ) );
-
-			// This will mostly just wipe the session.
-			$this->abandon_checkout_order( $order );
-		}
-
-		// Now if we don't have an order right now, we should not have a session either, so fix that
-		if ( ! $order ) {
-			$this->abandon_checkout_order( false );
-		}
-
-		// Now check the orders vipps session if it exist
-		$session = $order ? $order->get_meta( WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION ) : false;
-
-		// A single word or array containing session data, containing token and frontendFrameUrl
-		// ERROR EXPIRED FAILED
-		$session_status = $session ? $this->get_checkout_status( $session ) : null;
-
-		// If this is the case, there is no redirect, but the session is gone, so wipe the order and session.
-		if ( in_array( $session_status, [ 'ERROR', 'EXPIRED', 'FAILED' ] ) ) {
-			WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Vipps/MobilePay checkout session is gone", $order->get_id() ) );
-			$this->abandon_checkout_order( $order );
-		}
-
-		// This will return either a valid vipps session, nothing, or redirect.
-		return [
-			'success'      => (bool) $order,
-			'order'        => $order ? $order->get_id() : false,
-			'session'      => $session,
-			'redirect_url' => $redirect
-		];
-	}
-
-	/**
-	 * @param $session
-	 *
-	 * @return string
-	 */
-	public function get_checkout_status( $session ): string {
-		if ( $session && isset( $session['token'] ) ) {
-			try {
-				WC_Vipps_Recurring_Logger::log( "Polling checkout from get_checkout_status" );
-				$response = $this->gateway()->api->checkout_poll( $session['pollingUrl'] );
-
-				return $response['sessionState'] ?? "PaymentInitiated";
-			} catch ( WC_Vipps_Recurring_Exception $e ) {
-				if ( $e->responsecode == 400 ) {
-					return 'PaymentInitiated';
-				} else if ( $e->responsecode == 404 ) {
-					return 'SessionExpired';
-				} else {
-					WC_Vipps_Recurring_Logger::log( sprintf( "Error polling status - error message %s", $e->getMessage() ) );
-
-					return 'ERROR';
-				}
-			} catch ( Exception $e ) {
-				WC_Vipps_Recurring_Logger::log( sprintf( "Error polling status - error message %s", $e->getMessage() ) );
-
-				return 'ERROR';
-			}
-		}
-
-		return "ERROR";
-	}
-
-	public function abandon_checkout_order( $order ) {
-		if ( WC()->session ) {
-			WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_CHECKOUT_PENDING_ORDER_ID, 0 );
-			WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_ADDRESS_HASH, false );
-		}
-
-		if ( is_a( $order, 'WC_Order' ) && $order->get_status() === 'pending' ) {
-			// We want to kill orders that have failed, or that the user has abandoned. To do this,
-			// we must ensure that no race or other mechanism kills the order while or after being paid.
-			// if order is in the process of being finalized, don't kill it
-			if ( WC_Vipps_Recurring_Helper::order_locked( $order ) ) {
-				return false;
-			}
-
-			// Get it again to ensure we have all the info, and check status again
-			clean_post_cache( $order->get_id() );
-			$order = wc_get_order( $order->get_id() );
-			if ( $order->get_status() !== 'pending' ) {
-				return false;
-			}
-
-			// And to be extra sure, check status at Vipps/MobilePay
-			$session       = $order->get_meta( WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION );
-			$poll_endpoint = ( $session && isset( $session['pollingUrl'] ) ) ? $session['pollingUrl'] : false;
-
-			if ( $poll_endpoint ) {
-				try {
-					WC_Vipps_Recurring_Logger::log( "Polling checkout from abandon_checkout_order" );
-					$poll_data     = $this->gateway()->api->checkout_poll( $poll_endpoint );
-					$session_state = ( ! empty( $poll_data ) && is_array( $poll_data ) && isset( $poll_data['sessionState'] ) ) ? $poll_data['sessionState'] : "";
-					WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Checking Checkout status on cart/order change: %s", $order->get_id(), $session_state ) );
-					if ( $session_state === 'PaymentSuccessful' || $session_state === 'PaymentInitiated' ) {
-						// If we have started payment, we do not kill the order.
-						WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Checkout payment started - cannot cancel", $order->get_id() ) );
-
-						return false;
-					}
-				} catch ( Exception $e ) {
-					WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Could not get Checkout status for order. Order is still in progress while cancelling', $order->get_id() ) );
-				}
-			}
-
-			// NB: This can *potentially* be revived by a callback!
-			WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Cancelling Checkout order because order changed', $order->get_id() ) );
-			$order->set_status( 'cancelled', __( "Order specification changed - order abandoned by customer in Checkout", 'woo-vipps' ), false );
-
-			// Also mark for deletion and remove stored session
-			WC_Vipps_Recurring_Helper::delete_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION );
-
-			// Stop checking the status of this order in cron
-			WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, false );
-
-			// This is dealt with by a cron schedule
-			if ( $this->gateway()->get_option( 'checkout_cleanup_abandoned_orders' ) === 'yes' ) {
-				WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_MARKED_FOR_DELETION, 1 );
-			}
-
-			$order->save();
-		}
-	}
-
-	/**
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 * @throws WC_Data_Exception
-	 */
-	public function handle_callback( array $body, string $authorization_token ): void {
-		WC_Vipps_Recurring_Logger::log( sprintf( "Handling Vipps/MobilePay Checkout callback with body: %s", json_encode( $body ) ) );
-
-		$orders = wc_get_orders( [
-			'meta_query' => [
-				[
-					'key'     => WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION_ID,
-					'compare' => '=',
-					'value'   => $body['sessionId']
-				]
-			]
-		] );
-
-		if ( empty( $orders ) ) {
-			WC_Vipps_Recurring_Logger::log( sprintf( "Found no order ids in Vipps/MobilePay Checkout callback for session id: %s", $body['sessionId'] ) );
-
-			return;
-		}
-
-		$order = array_pop( $orders );
-
-		$stored_authorization_token = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_EXPRESS_AUTH_TOKEN );
-		if ( $authorization_token !== $stored_authorization_token ) {
-			WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Invalid authorization token for session id %s.", WC_Vipps_Recurring_Helper::get_id( $order ), $body['sessionId'] ) );
-
-			return;
-		}
-
-		$this->handle_payment( $order, $body );
-	}
-
-	/**
-	 * @param WC_Order $order
-	 * @param array $session
-	 *
-	 * @return void
-	 * @throws WC_Data_Exception
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 * @throws Exception
-	 */
-	public function handle_payment( WC_Order $order, array $session ): void {
-		$order_id     = WC_Vipps_Recurring_Helper::get_id( $order );
-		$agreement_id = $session['subscriptionDetails']['agreementId'];
-		$status       = $session['sessionState'];
-
-		if ( empty( $agreement_id ) ) {
-			return;
-		}
-
-		WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Handling Vipps/MobilePay Checkout payment for agreement ID %s with status %s", $order_id, $agreement_id, $status ) );
-
-		// This makes sure we are covered by all our normal cron checks as well
-		WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, $agreement_id );
-
-		$order_charge_id = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID );
-		if ( empty( $order_charge_id ) ) {
-			$charges = $this->gateway()->api->get_charges_for( $agreement_id );
-			/** @var WC_Vipps_Charge $charge */
-			$charge = array_pop( $charges );
-
-			WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $charge->id );
-		}
-
-		$order->save();
-
-		// "SessionCreated" "PaymentInitiated" "SessionExpired" "PaymentSuccessful" "PaymentTerminated"
-		if ( in_array( $status, [ 'SessionExpired', 'PaymentTerminated' ] ) ) {
-			$this->abandon_checkout_order( $order );
-
-			return;
-		}
-
-		if ( $status !== 'PaymentSuccessful' ) {
-			return;
-		}
-
-		// Create a subscription on success, and set all the required values like _charge_id, _agreement_id, and so on.
-		// On success, we might have to create a user as well, if they don't already exist, this is because Woo Subscriptions REQUIRE a user.
-		if ( ! $order->get_customer_id( 'edit' ) ) {
-			$email   = $session['billingDetails']['email'];
-			$user    = get_user_by( 'email', $email );
-			$user_id = $user->ID;
-
-			if ( ! $user_id ) {
-				WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Handling Vipps/MobilePay Checkout payment: creating a new customer", $order_id ) );
-
-				$username = wc_create_new_customer_username( $email );
-				$user_id  = wc_create_new_customer( $email, $username, null );
-
-				$customer = new WC_Customer( $user_id );
-				$this->maybe_update_billing_and_shipping( $customer, $session );
-
-				// Send a password reset link right away.
-				$user_data = get_user_by( 'ID', $user_id );
-
-				$key = get_password_reset_key( $user_data );
-
-				WC()->mailer();
-				do_action( 'woocommerce_reset_password_notification', $user_data->user_login, $key );
-
-				// Log the user in, if we have a valid session.
-				if ( WC()->session ) {
-					wc_set_customer_auth_cookie( $user_id );
-				}
-			}
-
-			$order->set_customer_id( $user_id );
-			$order->save();
-		}
-
-		$this->maybe_update_billing_and_shipping( $order, $session );
-
-		// Update subscription with the correct customer id, and agreement id
-		$existing_subscriptions = wcs_get_subscriptions_for_order( $order );
-
-		/** @var WC_Subscription $subscription */
-		$subscription = array_pop( $existing_subscriptions );
-
-		if ( ! $subscription ) {
-			return;
-		}
-
-		WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, $agreement_id );
-
-		$subscription->set_customer_id( $order->get_customer_id( 'edit' ) );
-		wcs_copy_order_address( $order, $subscription );
-		$subscription->save();
-
-		$this->gateway()->check_charge_status( $order_id, true );
-
-		// This is passed off to regular cron or API handling after this point
-		WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Finished handling Vipps/MobilePay Checkout payment for agreement ID %s", $order_id, $agreement_id ) );
-	}
-
-	public function maybe_update_billing_and_shipping( $object, $session ): void {
-		$contact = $session['billingDetails'] ?? $session['shippingDetails'];
-
-		if ( empty( $contact ) ) {
-			return;
-		}
-
-		$object->set_billing_email( $contact['email'] );
-		$object->set_billing_phone( '+' . $contact['phoneNumber'] );
-		$object->set_billing_first_name( $contact['firstName'] );
-		$object->set_billing_last_name( $contact['lastName'] );
-		$object->set_billing_address_1( $contact['streetAddress'] );
-		$object->set_billing_city( $contact['city'] );
-		$object->set_billing_postcode( $contact['postalCode'] );
-		$object->set_billing_country( $contact['country'] );
-
-		if ( isset( $session['shippingDetails'] ) ) {
-			$contact = $session['shippingDetails'];
-		}
-
-		$object->set_shipping_first_name( $contact['firstName'] );
-		$object->set_shipping_last_name( $contact['lastName'] );
-		$object->set_shipping_address_1( $contact['streetAddress'] );
-		$object->set_shipping_city( $contact['city'] );
-		$object->set_shipping_postcode( $contact['postalCode'] );
-		$object->set_shipping_country( $contact['country'] );
-
-		$object->save();
-	}
-
-	public function maybe_cancel_initial_order( WC_Order $order ): void {
-		$created = $order->get_date_created();
-		$now     = time();
-
-		try {
-			$timestamp = $created->getTimestamp();
-		} catch ( Exception $e ) {
-			// PHP 8 gives ValueError for certain older versions of WooCommerce here.
-			$timestamp = intval( $created->format( 'U' ) );
-		}
-
-		$passed  = $now - $timestamp;
-		$minutes = ( $passed / 60 );
-
-		if ( $order->get_status() === 'pending' && $minutes > 120 ) {
-			$this->abandon_checkout_order( $order );
-		}
-	}
-
-	public function user_has_subscription( $has_subscription, $user_id, $product_id, $status ) {
-		$subscriptions = wcs_get_users_subscriptions( $user_id );
-
-		foreach ( $subscriptions as $subscription ) {
-			if ( ! WC_Vipps_Recurring_Helper::get_meta( $subscription, WC_Vipps_Recurring_Helper::META_ORDER_IS_CHECKOUT ) ) {
-				continue;
-			}
-
-			// You do not have a subscription simply because you have a pending subscription.
-			// Checkout subscriptions are created BEFORE a payment is made.
-			if ( $subscription->has_status( 'pending' ) ) {
-				$has_subscription = false;
-				break;
-			}
-		}
-
-		return $has_subscription;
-	}
+    private static ?WC_Vipps_Recurring_Checkout $instance = null;
+
+    private ?WC_Gateway_Vipps_Recurring $gateway = null;
+
+    /**
+     * Returns the *Singleton* instance of this class.
+     *
+     * @return WC_Vipps_Recurring_Checkout The *Singleton* instance.
+     */
+    public static function get_instance(): WC_Vipps_Recurring_Checkout {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public static function register_hooks(): void {
+        $instance = WC_Vipps_Recurring_Checkout::get_instance();
+        add_action( 'init', [ $instance, 'init' ] );
+        // Higher priority than the single payments Vipps plugin
+        add_filter( 'woocommerce_get_checkout_page_id', [ $instance, 'woocommerce_get_checkout_page_id' ], 20 );
+        add_action( 'template_redirect', [ $instance, 'template_redirect' ] );
+
+        if ( is_admin() ) {
+            add_action( 'admin_init', [ $instance, 'admin_init' ] );
+        }
+    }
+
+    public function gateway(): ?WC_Gateway_Vipps_Recurring {
+        if ( $this->gateway ) {
+            return $this->gateway;
+        }
+
+        $this->gateway = WC_Vipps_Recurring::get_instance()->gateway();
+
+        return $this->gateway;
+    }
+
+    public function maybe_load_cart(): void {
+        if ( version_compare( WC_VERSION, '3.6.0', '>=' ) && WC()->is_rest_api_request() ) {
+            if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+                return;
+            }
+
+            $rest_prefix = WC_Vipps_Recurring_Checkout_Rest_Api::$api_namespace;
+            $req_uri     = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+
+            $is_my_endpoint = ( false !== strpos( $req_uri, $rest_prefix ) );
+
+            if ( ! $is_my_endpoint ) {
+                return;
+            }
+
+            require_once WC_ABSPATH . 'includes/wc-cart-functions.php';
+            require_once WC_ABSPATH . 'includes/wc-notice-functions.php';
+
+            if ( null === WC()->session ) {
+                $session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+
+                // Prefix session class with global namespace if not already namespaced
+                if ( false === strpos( $session_class, '\\' ) ) {
+                    $session_class = '\\' . $session_class;
+                }
+
+                WC()->session = new $session_class();
+                WC()->session->init();
+            }
+
+            /**
+             * For logged in customers, pull data from their account rather than the
+             * session which may contain incomplete data.
+             */
+            if ( is_null( WC()->customer ) ) {
+                if ( is_user_logged_in() ) {
+                    WC()->customer = new WC_Customer( get_current_user_id() );
+                } else {
+                    WC()->customer = new WC_Customer( get_current_user_id(), true );
+                }
+
+                // Customer should be saved during shutdown.
+                add_action( 'shutdown', array( WC()->customer, 'save' ), 10 );
+            }
+
+            // Load Cart.
+            if ( null === WC()->cart ) {
+                WC()->cart = new WC_Cart();
+            }
+        }
+    }
+
+    public function init(): void {
+        require_once __DIR__ . '/wc-vipps-recurring-checkout-rest-api.php';
+        WC_Vipps_Recurring_Checkout_Rest_Api::get_instance();
+
+        add_action( 'wp_loaded', [ $this, 'maybe_load_cart' ], 5 );
+
+        add_action( 'wp_loaded', [ $this, 'register_scripts' ] );
+
+        // Prevent previews and prefetches of the Vipps Checkout page starting and creating orders
+        add_action( 'wp_head', [ $this, 'wp_head' ] );
+
+        // The Vipps MobilePay Checkout feature which overrides the normal checkout process uses a shortcode
+        add_shortcode( 'vipps_recurring_checkout', [ $this, 'shortcode' ] );
+
+        add_action( 'wc_vipps_recurring_before_cron_check_order_status', [ $this, 'check_order_status' ] );
+        add_action( 'wc_vipps_recurring_before_rest_api_check_order_status', [ $this, 'check_order_status' ] );
+
+        // For Checkout, we need to know any time and as soon as the cart changes, so fold all the events into a single one
+        add_action( 'woocommerce_add_to_cart', function () {
+            do_action( 'vipps_recurring_cart_changed', 'woocommerce_add_to_cart' );
+        }, 10, 0 );
+
+        // Cart coupon applied
+        add_action( 'woocommerce_applied_coupon', function () {
+            do_action( 'vipps_recurring_cart_changed', 'woocommerce_applied_coupon' );
+        }, 10, 0 );
+
+        // Cart emptied
+        add_action( 'woocommerce_cart_emptied', function () {
+            do_action( 'vipps_recurring_cart_changed', 'woocommerce_cart_emptied' );
+        }, 10, 0 );
+
+        // After updating quantities
+        add_action( 'woocommerce_after_cart_item_quantity_update', function () {
+            do_action( 'vipps_recurring_cart_changed', 'woocommerce_after_cart_item_quantity_update' );
+        }, 10, 0 );
+
+        // Blocks and ajax
+        add_action( 'woocommerce_cart_item_removed', function () {
+            do_action( 'vipps_recurring_cart_changed', 'woocommerce_cart_item_removed' );
+        }, 10, 0 );
+
+        // Restore deleted entry
+        add_action( 'woocommerce_cart_item_restored', function () {
+            do_action( 'vipps_recurring_cart_changed', 'woocommerce_cart_item_restored' );
+        }, 10, 0 );
+
+        // Normal cart form update
+        add_filter( 'woocommerce_update_cart_action_cart_updated', function ( $updated ) {
+            do_action( 'vipps_recurring_cart_changed', 'woocommerce_update_cart_action_cart_updated' );
+
+            return $updated;
+        } );
+
+        // Then handle the actual cart change
+        add_action( 'vipps_recurring_cart_changed', [ $this, 'cart_changed' ] );
+
+        add_action( 'wc_vipps_recurring_checkout_callback', [ $this, 'handle_callback' ], 10, 2 );
+
+        // Handle cancelled orders
+        add_action( 'wc_vipps_recurring_check_charge_status_no_agreement', [ $this, 'maybe_cancel_initial_order' ] );
+
+        add_filter( 'wcs_user_has_subscription', [ $this, 'user_has_subscription' ], 10, 4 );
+    }
+
+    public function admin_init(): void {
+        // Checkout page
+        add_filter( 'woocommerce_settings_pages', array( $this, 'woocommerce_settings_pages' ) );
+    }
+
+    /**
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     * @throws WC_Vipps_Recurring_Config_Exception
+     */
+    public function maybe_create_session(): array {
+        $redirect_url = null;
+        $token        = null;
+        $url          = null;
+
+        $session = WC_Vipps_Recurring_Checkout::get_instance()->current_pending_session();
+
+        if ( isset( $session['redirect_url'] ) ) {
+            $redirect_url = $session['redirect_url'];
+        }
+
+        if ( isset( $session['session']['token'] ) ) {
+            $token = $session['session']['token'];
+            $src   = $session['session']['checkoutFrontendUrl'];
+            $url   = $src;
+        }
+
+        if ( $url ) {
+            $pending_order_id = WC_Vipps_Recurring_Helper::get_checkout_pending_order_id();
+
+            return [
+                'success'      => true,
+                'src'          => $url,
+                'redirect_url' => $redirect_url,
+                'token'        => $token,
+                'order_id'     => $pending_order_id
+            ];
+        }
+
+        $session = null;
+
+        try {
+            $partial_order_id = WC_Gateway_Vipps_Recurring::get_instance()->create_partial_order( true );
+
+            $order      = wc_get_order( $partial_order_id );
+            $auth_token = WC_Gateway_Vipps_Recurring::get_instance()->api->generate_idempotency_key();
+
+            $order->update_meta_data( WC_Vipps_Recurring_Helper::META_ORDER_EXPRESS_AUTH_TOKEN, $auth_token );
+            $order->save();
+
+            WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_CHECKOUT_PENDING_ORDER_ID, $partial_order_id );
+            WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_ORDER_EXPRESS_AUTH_TOKEN, $auth_token );
+
+            do_action( 'wc_vipps_recurring_checkout_order_created', $order );
+        } catch ( Exception $exception ) {
+            return [
+                'success'      => false,
+                'msg'          => $exception->getMessage(),
+                'src'          => null,
+                'redirect_url' => null,
+                'order_id'     => 0
+            ];
+        }
+
+        $order = wc_get_order( $partial_order_id );
+
+        $session_orders = WC()->session->get( WC_Vipps_Recurring_Helper::SESSION_ORDERS );
+        if ( ! $session_orders ) {
+            $session_orders = [];
+        }
+
+        $session_orders[ $partial_order_id ] = 1;
+        WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_PENDING_ORDER_ID, $partial_order_id );
+        WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_ORDERS, $session_orders );
+
+        $customer_id = get_current_user_id();
+        if ( $customer_id ) {
+            $customer = new WC_Customer( $customer_id );
+        } else {
+            $customer = WC()->customer;
+        }
+
+        if ( $customer ) {
+            $customer_info['email']         = $customer->get_billing_email();
+            $customer_info['firstName']     = $customer->get_billing_first_name();
+            $customer_info['lastName']      = $customer->get_billing_last_name();
+            $customer_info['streetAddress'] = $customer->get_billing_address_1();
+            $address2                       = trim( $customer->get_billing_address_2() );
+
+            if ( ! empty( $address2 ) ) {
+                $customer_info['streetAddress'] = $customer_info['streetAddress'] . ", " . $address2;
+            }
+            $customer_info['city']       = $customer->get_billing_city();
+            $customer_info['postalCode'] = $customer->get_billing_postcode();
+            $customer_info['country']    = $customer->get_billing_country();
+
+            // Currently Vipps requires all phone numbers to have area codes and NO +. We can't guarantee that at all, but try for Norway
+            $normalized_phone_number = WC_Vipps_Recurring_Helper::normalize_phone_number( $customer->get_billing_phone(), $customer_info['country'] );
+            if ( $normalized_phone_number ) {
+                $customer_info['phoneNumber'] = $normalized_phone_number;
+            }
+        }
+
+        $keys = [ 'firstName', 'lastName', 'streetAddress', 'postalCode', 'country', 'phoneNumber' ];
+        foreach ( $keys as $k ) {
+            if ( empty( $customer_info[ $k ] ) ) {
+                $customer_info = [];
+                break;
+            }
+        }
+        $customer_info = apply_filters( 'wc_vipps_recurring_customer_info', $customer_info, $order );
+
+        // todo: throw an error if we try to purchase a product with a location based shipping method?
+        try {
+            $checkout = WC_Vipps_Recurring_Checkout::get_instance();
+            $gateway  = $checkout->gateway();
+
+            $order_prefix = $gateway->order_prefix;
+
+            // hack - fake "Anonymous Vipps/MobilePay User"
+            $fake_user = false;
+            if ( ! $order->get_customer_id( 'edit' ) ) {
+                $fake_user = true;
+
+                $order->set_customer_id( $this->gateway()->create_or_get_anonymous_system_customer()->get_id() );
+                $order->save();
+            }
+
+            $subscriptions = $gateway->create_partial_subscriptions_from_order( $order );
+
+            // reset hack
+            if ( $fake_user ) {
+                $order->set_customer_id( 0 );
+                $order->save();
+            }
+
+            $subscription = array_pop( $subscriptions );
+
+            // Remove this action to avoid making an unnecessary API request
+            remove_action( 'woocommerce_order_after_calculate_totals', [
+                $this->gateway(),
+                'update_agreement_price_in_app'
+            ] );
+
+            $subscription->calculate_totals();
+            $subscription->save();
+
+            $agreement = $gateway->create_vipps_agreement_from_order( $order, $subscription );
+
+            $checkout_subscription = ( new WC_Vipps_Checkout_Session_Subscription() )
+                ->set_amount(
+                    ( new WC_Vipps_Checkout_Session_Amount() )
+                        ->set_value( $agreement->pricing->amount )
+                        ->set_currency( $agreement->pricing->currency )
+                )
+                ->set_product_name( $agreement->product_name )
+                ->set_interval( $agreement->interval )
+                ->set_merchant_agreement_url( $agreement->merchant_agreement_url );
+
+            if ( $agreement->campaign ) {
+                $checkout_subscription = $checkout_subscription->set_campaign( $agreement->campaign );
+            }
+
+            if ( $agreement->product_description ) {
+                $checkout_subscription = $checkout_subscription->set_product_description( $agreement->product_description );
+            }
+
+            $customer = new WC_Vipps_Checkout_Session_Customer( $customer_info );
+
+            // Create a checkout session dto
+            $checkout_session = ( new WC_Vipps_Checkout_Session() )
+                ->set_type( WC_Vipps_Checkout_Session::TYPE_SUBSCRIPTION )
+                ->set_subscription( $checkout_subscription )
+                ->set_merchant_info(
+                    ( new WC_Vipps_Checkout_Session_Merchant_Info() )
+                        ->set_callback_url( $gateway->webhook_callback_url() )
+                        ->set_return_url( $agreement->merchant_redirect_url )
+                        ->set_callback_authorization_token( $auth_token )
+                )
+                ->set_prefill_customer( $customer )
+                ->set_configuration(
+                    ( new WC_Vipps_Checkout_Session_Configuration() )
+                        ->set_user_flow( WC_Vipps_Checkout_Session_Configuration::USER_FLOW_WEB_REDIRECT )
+                        ->set_customer_interaction( WC_Vipps_Checkout_Session_Configuration::CUSTOMER_INTERACTION_NOT_PRESENT )
+                        ->set_elements( WC_Vipps_Checkout_Session_Configuration::ELEMENTS_FULL )
+                        ->set_require_user_info( empty( $customer->email ) )
+                        ->set_show_order_summary( true )
+                );
+
+            if ( $agreement->initial_charge ) {
+                $reference = WC_Vipps_Recurring_Helper::generate_vipps_order_id( $order, $order_prefix );
+
+                $checkout_transaction = ( new WC_Vipps_Checkout_Session_Transaction() )
+                    ->set_reference( $reference )
+                    ->set_amount(
+                        ( new WC_Vipps_Checkout_Session_Amount() )
+                            ->set_value( $agreement->initial_charge->amount )
+                            ->set_currency( $agreement->pricing->currency )
+                    )
+                    ->set_order_summary( $checkout->make_order_summary( $order ) );
+
+                if ( $agreement->initial_charge->description ) {
+                    $checkout_transaction = $checkout_transaction->set_payment_description( $agreement->initial_charge->description );
+                }
+
+                $checkout_session = $checkout_session->set_transaction( $checkout_transaction );
+
+                WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $reference );
+            }
+
+            $checkout_session = apply_filters( 'wc_vipps_recurring_checkout_session', $checkout_session, $order );
+
+            $session = WC_Gateway_Vipps_Recurring::get_instance()->api->checkout_initiate( $checkout_session );
+
+            $order = wc_get_order( $partial_order_id );
+            WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, true );
+            WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_INITIAL, true );
+            WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION, $session->to_array() );
+
+            $session_poll = WC_Gateway_Vipps_Recurring::get_instance()->api->checkout_poll( $session->polling_url );
+            WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION_ID, $session_poll['sessionId'] );
+
+            $order->add_order_note( __( 'Vipps/MobilePay recurring checkout payment initiated', 'woo-vipps' ) );
+            $order->add_order_note( __( 'Customer passed to Vipps/MobilePay checkout', 'woo-vipps' ) );
+            $order->save();
+
+            $token = $session->token;
+            $src   = $session->checkout_frontend_url;
+            $url   = $src;
+        } catch ( Exception $e ) {
+            WC_Vipps_Recurring_Logger::log( sprintf( "Could not initiate Vipps/MobilePay checkout session: %s", $e->getMessage() ) );
+
+            return [
+                'success'      => false,
+                'msg'          => $e->getMessage(),
+                'src'          => null,
+                'redirect_url' => null,
+                'order_id'     => $partial_order_id
+            ];
+        }
+
+        if ( $url || $redirect_url ) {
+            return [
+                'success'      => true,
+                'msg'          => 'session started',
+                'src'          => $url,
+                'redirect_url' => $redirect_url,
+                'token'        => $token,
+                'order_id'     => $partial_order_id
+            ];
+        }
+
+        return [
+            'success'      => false,
+            'msg'          => __( 'Could not start Vipps/MobilePay checkout session', 'woo-vipps' ),
+            'src'          => $url,
+            'redirect_url' => $redirect_url,
+            'order_id'     => $partial_order_id
+        ];
+    }
+
+    public function maybe_login_checkout_user( int $order_id, ?string $key = null ): void {
+        if ( ! $key ) {
+            return;
+        }
+
+        $order = wc_get_order( $order_id );
+        if ( ! $order ) {
+            return;
+        }
+
+        $order_key_db = $order->get_order_key( 'code' );
+        if ( $order_key_db !== $key ) {
+            return;
+        }
+
+        // Attempt to log the user in
+        $session_auth_token = WC()->session->get( WC_Vipps_Recurring_Helper::SESSION_ORDER_EXPRESS_AUTH_TOKEN );
+        $order_auth_token   = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_EXPRESS_AUTH_TOKEN );
+
+        if ( $order_auth_token !== $session_auth_token ) {
+            return;
+        }
+
+        $user = $order->get_user();
+
+        wc_set_customer_auth_cookie( $user->ID );
+        WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_ORDER_EXPRESS_AUTH_TOKEN, null );
+    }
+
+    public function cart_changed( string $source ): void {
+        $pending_order_id = is_a( WC()->session, 'WC_Session' ) ? WC()->session->get( WC_Vipps_Recurring_Helper::SESSION_CHECKOUT_PENDING_ORDER_ID ) : false;
+        $order            = $pending_order_id ? wc_get_order( $pending_order_id ) : null;
+
+        if ( ! $order ) {
+            return;
+        }
+
+        WC_Vipps_Recurring_Logger::log( sprintf( "Checkout cart changed while session %d in progress, attempting to cancel. Source: %s", $order->get_id(), $source ) );
+        $this->abandon_checkout_order( $order );
+    }
+
+    /**
+     * @throws WC_Vipps_Recurring_Config_Exception
+     * @throws WC_Data_Exception
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     */
+    public function check_order_status( $order_id ): void {
+        $lock_name = "vipps_recurring_checkout_check_order_status_$order_id";
+        $lock      = get_transient( $lock_name );
+
+        if ( $lock ) {
+            return;
+        }
+
+        set_transient( $lock_name, uniqid( '', true ), 5 );
+
+        $order = wc_get_order( $order_id );
+
+        if ( ! WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_IS_CHECKOUT ) ) {
+            return;
+        }
+
+        $session = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION );
+        if ( ! is_array( $session ) ) {
+            return;
+        }
+
+        $session = $this->gateway()->api->checkout_poll( $session['pollingUrl'] );
+
+        $this->handle_payment( $order, $session );
+    }
+
+    public function woocommerce_settings_pages( $settings ) {
+        $checkout_enabled = get_option( WC_Vipps_Recurring_Helper::OPTION_CHECKOUT_ENABLED, false );
+        if ( ! $checkout_enabled ) {
+            return $settings;
+        }
+
+        // Find out where the end of the section advanced_page_options is
+        $i     = 0;
+        $count = count( $settings );
+
+        for ( ; $i < $count; $i ++ ) {
+            if ( $settings[ $i ]['type'] === 'sectionend' && $settings[ $i ]['id'] === 'advanced_page_options' ) {
+                break;
+            }
+        }
+
+        if ( $i < $count ) {
+            array_splice( $settings, $i, 0, [
+                [
+                    'title'    => __( 'Vipps/MobilePay Recurring Checkout Page', 'woo-vipps' ),
+                    'desc'     => __( 'This page is used for the alternative Vipps/MobilePay checkout page, which you can choose to use instead of the normal WooCommerce checkout page. ', 'woo-vipps' ) . sprintf( __( 'Page contents: [%1$s]', 'woocommerce' ), 'vipps_recurring_checkout' ),
+                    'id'       => 'woocommerce_vipps_recurring_checkout_page_id',
+                    'type'     => 'single_select_page_with_search',
+                    'default'  => '',
+                    'class'    => 'wc-page-search',
+                    'css'      => 'min-width:300px;',
+                    'args'     => [
+                        'exclude' =>
+                            [
+                                wc_get_page_id( 'myaccount' ),
+                            ],
+                    ],
+                    'desc_tip' => true,
+                    'autoload' => false,
+                ]
+            ] );
+        }
+
+        return $settings;
+    }
+
+    public function woocommerce_get_checkout_page_id( $id ): int {
+        $checkout_enabled = get_option( WC_Vipps_Recurring_Helper::OPTION_CHECKOUT_ENABLED, false );
+
+        if ( ! $checkout_enabled ) {
+            return $id;
+        }
+
+        $checkout_id = $this->gateway()->checkout_is_available();
+        if ( $checkout_id ) {
+            return $checkout_id;
+        }
+
+        return $id;
+    }
+
+    public function template_redirect(): void {
+        global $post;
+
+        if ( $post && is_page() && has_shortcode( $post->post_content, 'vipps_recurring_checkout' ) ) {
+            add_filter( 'woocommerce_is_checkout', '__return_true' );
+
+            add_filter( 'body_class', function ( $classes ) {
+                $classes[] = 'vipps-recurring-checkout';
+                $classes[] = 'woocommerce-checkout'; // Required by Pixel Your Site
+
+                return apply_filters( 'wc_vipps_recurring_checkout_body_class', $classes );
+            } );
+
+            // Suppress the title for this page
+            $post_to_hide_title_for = $post->ID;
+            add_filter( 'the_title', function ( $title, $postid = 0 ) use ( $post_to_hide_title_for ) {
+                if ( ! is_admin() && $postid == $post_to_hide_title_for && is_singular() && in_the_loop() ) {
+                    $title = "";
+                }
+
+                return $title;
+            }, 10, 2 );
+
+            wc_nocache_headers();
+        }
+    }
+
+    public function wp_head(): void {
+        // If we have a Vipps MobilePay Checkout page, stop iOS from giving previews of it that
+        // starts the session - iOS should use the visibility API of the browser for this, but it doesn't as of 2021-11-11
+        $checkout_id = wc_get_page_id( 'vipps_recurring_checkout' );
+        if ( $checkout_id ) {
+            $url = get_permalink( $checkout_id );
+            echo "<style> a[href=\"$url\"] { -webkit-touch-callout: none;  } </style>\n";
+        }
+    }
+
+    public function register_scripts(): void {
+        $sdk_url = 'https://checkout.vipps.no/vippsCheckoutSDK.js';
+        wp_register_script( 'woo-vipps-recurring-sdk', $sdk_url );
+
+        // Register our React component
+        wp_enqueue_style(
+            'woo-vipps-recurring-checkout',
+
+            WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/build/checkout.css', [],
+            filemtime( WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/checkout.css' )
+        );
+
+        $asset = require WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/checkout.asset.php';
+
+        wp_enqueue_script(
+            'woo-vipps-recurring-checkout',
+            WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/build/checkout.js',
+            array_merge( $asset['dependencies'], [ 'woo-vipps-recurring', 'woo-vipps-recurring-sdk' ] ),
+            filemtime( WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/checkout.js' ),
+            true
+        );
+    }
+
+    /**
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     * @throws WC_Vipps_Recurring_Config_Exception
+     */
+    public function shortcode() {
+        global $wp;
+
+        if ( is_admin() || wp_doing_ajax() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+            return false;
+        }
+
+        // No point in expanding this unless we are actually doing the checkout. IOK 2021-09-03
+        wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
+        add_filter( 'wc_vipps_recurring_is_vipps_checkout', '__return_true' );
+
+        if ( is_wc_endpoint_url( 'order-received' ) ) {
+            $order_id = absint( $wp->query_vars['order-received'] );
+            $this->maybe_login_checkout_user( $order_id, $_GET['key'] ?? null );
+        }
+
+        // Defer to the normal code for endpoints IOK 2022-12-09
+        if ( is_wc_endpoint_url( 'order-pay' ) || is_wc_endpoint_url( 'order-received' ) ) {
+            return do_shortcode( "[woocommerce_checkout]" );
+        }
+
+        if ( ! WC()->cart || WC()->cart->is_empty() ) {
+            $this->abandon_checkout_order( false );
+            ob_start();
+            wc_get_template( 'cart/cart-empty.php' );
+
+            return ob_get_clean();
+        }
+
+        // Previously registered, now enqueue this script which should then appear in the footer.
+        wp_enqueue_script( 'vipps-recurring-checkout' );
+
+        do_action( 'vipps_recurring_checkout_before_get_session' );
+
+        // Localize script with variables we need to reveal to the frontend
+        $data = $this->current_pending_session();
+        if ( empty( $data['session'] ) ) {
+            $data['session'] = $this->maybe_create_session();
+        }
+
+        wp_add_inline_script( 'woo-vipps-recurring-checkout', 'window.VippsRecurringCheckout = ' . wp_json_encode( $data ), 'before' );
+
+        return '<div id="vipps-mobilepay-recurring-checkout"></div>';
+    }
+
+    public function make_order_summary( $order ): WC_Vipps_Checkout_Session_Transaction_Order_Summary {
+        $order_lines = [];
+
+        $bottom_line = ( new WC_Vipps_Checkout_Session_Transaction_Order_Summary_Bottom_Line() )
+            ->set_currency( $order->get_currency() )
+            ->set_gift_card_amount( apply_filters( 'wc_vipps_recurring_order_gift_card_amount', 0, $order ) * 100 )
+            ->set_tip_amount( apply_filters( 'wc_vipps_recurring_order_tip_amount', 0, $order ) * 100 )
+            ->set_terminal_id( apply_filters( 'wc_vipps_recurring_order_terminal_id', 'woocommerce', $order ) )
+            ->set_receipt_number( strval( WC_Vipps_Recurring_Helper::get_id( $order ) ) );
+
+        foreach ( $order->get_items() as $order_item ) {
+            $order_line      = [];
+            $product_id      = $order_item->get_product_id(); // sku can be tricky
+            $total_no_tax    = $order_item->get_total();
+            $tax             = $order_item->get_total_tax();
+            $total           = $tax + $total_no_tax;
+            $subtotal_no_tax = $order_item->get_subtotal();
+            $subtotal_tax    = $order_item->get_subtotal_tax();
+            $subtotal        = $subtotal_no_tax + $subtotal_tax;
+            $quantity        = $order_item->get_quantity();
+            $unit_price      = $subtotal / $quantity;
+
+            // Must do this to avoid rounding errors, since we get floats instead of money here :(
+            $discount = round( 100 * $subtotal ) - round( 100 * $total );
+            if ( $discount < 0 ) {
+                $discount = 0;
+            }
+
+            $product = wc_get_product( $product_id );
+            $url     = home_url( "/" );
+            if ( $product ) {
+                $url = get_permalink( $product_id );
+            }
+
+            if ( $subtotal_no_tax == 0 ) {
+                $tax_percentage = 0;
+            } else {
+                $tax_percentage = ( ( $subtotal - $subtotal_no_tax ) / $subtotal_no_tax ) * 100;
+            }
+            $tax_percentage = abs( round( $tax_percentage ) );
+
+            $unit_info                             = [];
+            $order_line['name']                    = $order_item->get_name();
+            $order_line['id']                      = strval( $product_id );
+            $order_line['totalAmount']             = round( $total * 100 );
+            $order_line['totalAmountExcludingTax'] = round( $total_no_tax * 100 );
+            $order_line['totalTaxAmount']          = round( $tax * 100 );
+            $order_line['taxRate']                 = round( $tax_percentage * 100 );
+
+            $unit_info['unitPrice']    = round( $unit_price * 100 );
+            $unit_info['quantity']     = strval( $quantity );
+            $unit_info['quantityUnit'] = 'PCS';
+            $order_line['unitInfo']    = $unit_info;
+            $order_line['discount']    = $discount;
+            $order_line['productUrl']  = $url;
+            $order_line['isShipping']  = false;
+
+            $order_lines[] = $order_line;
+        }
+
+        foreach ( $order->get_items( 'fee' ) as $order_item ) {
+            $order_line                            = [];
+            $total_no_tax                          = $order_item->get_total();
+            $tax                                   = $order_item->get_total_tax();
+            $total                                 = $tax + $total_no_tax;
+            $tax_percentage                        = ( ( $total - $total_no_tax ) / $total_no_tax ) * 100;
+            $tax_percentage                        = abs( round( $tax_percentage ) );
+            $order_line['name']                    = $order_item->get_name();
+            $order_line['id']                      = substr( sanitize_title( $order_line['name'] ), 0, 254 );
+            $order_line['totalAmount']             = round( $total * 100 );
+            $order_line['totalAmountExcludingTax'] = round( $total_no_tax * 100 );
+            $order_line['totalTaxAmount']          = round( $tax * 100 );
+            $order_line['discount']                = 0;
+            $order_line['taxRate']                 = round( $tax_percentage * 100 );
+
+            $order_lines[] = $order_line;
+        }
+
+        // Handle shipping
+        foreach ( $order->get_items( 'shipping' ) as $order_item ) {
+            $order_line         = [];
+            $order_line['name'] = $order_item->get_name();
+            $order_line['id']   = strval( $order_item->get_method_id() );
+            if ( method_exists( $order_item, 'get_instance_id' ) ) {
+                $order_line['id'] .= ":" . $order_item->get_instance_id();
+            }
+
+            $total_no_tax    = $order_item->get_total();
+            $tax             = $order_item->get_total_tax();
+            $total           = $tax + $total_no_tax;
+            $subtotal_no_tax = $total_no_tax;
+            $subtotal_tax    = $tax;
+            $subtotal        = $subtotal_no_tax + $subtotal_tax;
+
+            if ( $subtotal_no_tax == 0 ) {
+                $tax_percentage = 0;
+            } else {
+                $tax_percentage = ( ( $subtotal - $subtotal_no_tax ) / $subtotal_no_tax ) * 100;
+            }
+            $tax_percentage = abs( round( $tax_percentage ) );
+
+            $order_line['totalAmount']             = round( $total * 100 );
+            $order_line['totalAmountExcludingTax'] = round( $total_no_tax * 100 );
+            $order_line['totalTaxAmount']          = round( $tax * 100 );
+            $order_line['taxRate']                 = round( $tax_percentage * 100 );
+
+            $unit_info                 = [];
+            $unit_info['unitPrice']    = round( $total * 100 );
+            $unit_info['quantity']     = strval( 1 );
+            $unit_info['quantityUnit'] = 'PCS';
+
+            $order_line['unitInfo']   = $unit_info;
+            $discount                 = 0;
+            $order_line['discount']   = $discount;
+            $order_line['isShipping'] = true;
+
+            $order_lines[] = $order_line;
+        }
+
+        return ( new WC_Vipps_Checkout_Session_Transaction_Order_Summary() )
+            ->set_order_lines( $order_lines )
+            ->set_order_bottom_line( $bottom_line );
+    }
+
+    /**
+     * @throws WC_Vipps_Recurring_Config_Exception
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     */
+    public function current_pending_session(): array {
+        // If this is set, this is a currently pending order which is maybe still valid
+        $pending_order_id = WC_Vipps_Recurring_Helper::get_checkout_pending_order_id();
+        $order            = $pending_order_id ? wc_get_order( $pending_order_id ) : null;
+
+        # If we do have an order, we need to check if it is 'pending', and if not, we have to check its payment status
+        $payment_status = null;
+        $redirect       = null;
+
+        if ( $order ) {
+            if ( $order->get_status() === 'pending' ) {
+                $payment_status = 'INITIATED'; // Just assume this for now
+            } else {
+                $payment_status = $this->gateway()->check_charge_status( $pending_order_id, true ) ?? 'UNKNOWN';
+            }
+
+            if ( $payment_status === 'SUCCESS' ) {
+                $redirect = apply_filters( 'wc_vipps_recurring_merchant_redirect_url', WC_Vipps_Recurring_Helper::get_payment_redirect_url( $order ) );
+            }
+        }
+
+        if ( in_array( $payment_status, [ 'authorized', 'complete' ] ) ) {
+            $this->abandon_checkout_order( false );
+        } elseif ( $payment_status == 'cancelled' ) {
+            WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Vipps/MobilePay checkout session cancelled (pending session)", $order->get_id() ) );
+
+            // This will mostly just wipe the session.
+            $this->abandon_checkout_order( $order );
+        }
+
+        // Now if we don't have an order right now, we should not have a session either, so fix that
+        if ( ! $order ) {
+            $this->abandon_checkout_order( false );
+        }
+
+        // Now check the orders vipps session if it exist
+        $session = $order ? $order->get_meta( WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION ) : false;
+
+        // A single word or array containing session data, containing token and frontendFrameUrl
+        // ERROR EXPIRED FAILED
+        $session_status = $session ? $this->get_checkout_status( $session ) : null;
+
+        // If this is the case, there is no redirect, but the session is gone, so wipe the order and session.
+        if ( in_array( $session_status, [ 'ERROR', 'EXPIRED', 'FAILED' ] ) ) {
+            WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Vipps/MobilePay checkout session is gone", $order->get_id() ) );
+            $this->abandon_checkout_order( $order );
+        }
+
+        // This will return either a valid vipps session, nothing, or redirect.
+        return [
+            'success'      => (bool) $order,
+            'order'        => $order ? $order->get_id() : false,
+            'session'      => $session,
+            'redirect_url' => $redirect
+        ];
+    }
+
+    /**
+     * @param $session
+     *
+     * @return string
+     */
+    public function get_checkout_status( $session ): string {
+        if ( $session && isset( $session['token'] ) ) {
+            try {
+                WC_Vipps_Recurring_Logger::log( "Polling checkout from get_checkout_status" );
+                $response = $this->gateway()->api->checkout_poll( $session['pollingUrl'] );
+
+                return $response['sessionState'] ?? "PaymentInitiated";
+            } catch ( WC_Vipps_Recurring_Exception $e ) {
+                if ( $e->responsecode == 400 ) {
+                    return 'PaymentInitiated';
+                } else if ( $e->responsecode == 404 ) {
+                    return 'SessionExpired';
+                } else {
+                    WC_Vipps_Recurring_Logger::log( sprintf( "Error polling status - error message %s", $e->getMessage() ) );
+
+                    return 'ERROR';
+                }
+            } catch ( Exception $e ) {
+                WC_Vipps_Recurring_Logger::log( sprintf( "Error polling status - error message %s", $e->getMessage() ) );
+
+                return 'ERROR';
+            }
+        }
+
+        return "ERROR";
+    }
+
+    public function abandon_checkout_order( $order ) {
+        if ( WC()->session ) {
+            WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_CHECKOUT_PENDING_ORDER_ID, 0 );
+            WC()->session->set( WC_Vipps_Recurring_Helper::SESSION_ADDRESS_HASH, false );
+        }
+
+        if ( is_a( $order, 'WC_Order' ) && $order->get_status() === 'pending' ) {
+            // We want to kill orders that have failed, or that the user has abandoned. To do this,
+            // we must ensure that no race or other mechanism kills the order while or after being paid.
+            // if order is in the process of being finalized, don't kill it
+            if ( WC_Vipps_Recurring_Helper::order_locked( $order ) ) {
+                return false;
+            }
+
+            // Get it again to ensure we have all the info, and check status again
+            clean_post_cache( $order->get_id() );
+            $order = wc_get_order( $order->get_id() );
+            if ( $order->get_status() !== 'pending' ) {
+                return false;
+            }
+
+            // And to be extra sure, check status at Vipps/MobilePay
+            $session       = $order->get_meta( WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION );
+            $poll_endpoint = ( $session && isset( $session['pollingUrl'] ) ) ? $session['pollingUrl'] : false;
+
+            if ( $poll_endpoint ) {
+                try {
+                    WC_Vipps_Recurring_Logger::log( "Polling checkout from abandon_checkout_order" );
+                    $poll_data     = $this->gateway()->api->checkout_poll( $poll_endpoint );
+                    $session_state = ( ! empty( $poll_data ) && is_array( $poll_data ) && isset( $poll_data['sessionState'] ) ) ? $poll_data['sessionState'] : "";
+                    WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Checking Checkout status on cart/order change: %s", $order->get_id(), $session_state ) );
+                    if ( $session_state === 'PaymentSuccessful' || $session_state === 'PaymentInitiated' ) {
+                        // If we have started payment, we do not kill the order.
+                        WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Checkout payment started - cannot cancel", $order->get_id() ) );
+
+                        return false;
+                    }
+                } catch ( Exception $e ) {
+                    WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Could not get Checkout status for order. Order is still in progress while cancelling', $order->get_id() ) );
+                }
+            }
+
+            // NB: This can *potentially* be revived by a callback!
+            WC_Vipps_Recurring_Logger::log( sprintf( '[%s] Cancelling Checkout order because order changed', $order->get_id() ) );
+            $order->set_status( 'cancelled', __( "Order specification changed - order abandoned by customer in Checkout", 'woo-vipps' ), false );
+
+            // Also mark for deletion and remove stored session
+            WC_Vipps_Recurring_Helper::delete_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION );
+
+            // Stop checking the status of this order in cron
+            WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_PENDING, false );
+
+            // This is dealt with by a cron schedule
+            if ( $this->gateway()->get_option( 'checkout_cleanup_abandoned_orders' ) === 'yes' ) {
+                WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_MARKED_FOR_DELETION, 1 );
+            }
+
+            $order->save();
+        }
+    }
+
+    /**
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     * @throws WC_Vipps_Recurring_Config_Exception
+     * @throws WC_Data_Exception
+     */
+    public function handle_callback( array $body, string $authorization_token ): void {
+        WC_Vipps_Recurring_Logger::log( sprintf( "Handling Vipps/MobilePay Checkout callback with body: %s", json_encode( $body ) ) );
+
+        $orders = wc_get_orders( [
+            'meta_query' => [
+                [
+                    'key'     => WC_Vipps_Recurring_Helper::META_ORDER_CHECKOUT_SESSION_ID,
+                    'compare' => '=',
+                    'value'   => $body['sessionId']
+                ]
+            ]
+        ] );
+
+        if ( empty( $orders ) ) {
+            WC_Vipps_Recurring_Logger::log( sprintf( "Found no order ids in Vipps/MobilePay Checkout callback for session id: %s", $body['sessionId'] ) );
+
+            return;
+        }
+
+        $order = array_pop( $orders );
+
+        $stored_authorization_token = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_ORDER_EXPRESS_AUTH_TOKEN );
+        if ( $authorization_token !== $stored_authorization_token ) {
+            WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Invalid authorization token for session id %s.", WC_Vipps_Recurring_Helper::get_id( $order ), $body['sessionId'] ) );
+
+            return;
+        }
+
+        $this->handle_payment( $order, $body );
+    }
+
+    /**
+     * @param WC_Order $order
+     * @param array $session
+     *
+     * @return void
+     * @throws WC_Data_Exception
+     * @throws WC_Vipps_Recurring_Config_Exception
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     * @throws Exception
+     */
+    public function handle_payment( WC_Order $order, array $session ): void {
+        $order_id     = WC_Vipps_Recurring_Helper::get_id( $order );
+        $agreement_id = $session['subscriptionDetails']['agreementId'];
+        $status       = $session['sessionState'];
+
+        if ( empty( $agreement_id ) ) {
+            return;
+        }
+
+        WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Handling Vipps/MobilePay Checkout payment for agreement ID %s with status %s", $order_id, $agreement_id, $status ) );
+
+        // This makes sure we are covered by all our normal cron checks as well
+        WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, $agreement_id );
+
+        $order_charge_id = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID );
+        if ( empty( $order_charge_id ) ) {
+            $charges = $this->gateway()->api->get_charges_for( $agreement_id );
+            /** @var WC_Vipps_Charge $charge */
+            $charge = array_pop( $charges );
+
+            WC_Vipps_Recurring_Helper::update_meta_data( $order, WC_Vipps_Recurring_Helper::META_CHARGE_ID, $charge->id );
+        }
+
+        $order->save();
+
+        // "SessionCreated" "PaymentInitiated" "SessionExpired" "PaymentSuccessful" "PaymentTerminated"
+        if ( in_array( $status, [ 'SessionExpired', 'PaymentTerminated' ] ) ) {
+            $this->abandon_checkout_order( $order );
+
+            return;
+        }
+
+        if ( $status !== 'PaymentSuccessful' ) {
+            return;
+        }
+
+        // Create a subscription on success, and set all the required values like _charge_id, _agreement_id, and so on.
+        // On success, we might have to create a user as well, if they don't already exist, this is because Woo Subscriptions REQUIRE a user.
+        if ( ! $order->get_customer_id( 'edit' ) ) {
+            $email   = $session['billingDetails']['email'];
+            $user    = get_user_by( 'email', $email );
+            $user_id = $user->ID;
+
+            if ( ! $user_id ) {
+                WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Handling Vipps/MobilePay Checkout payment: creating a new customer", $order_id ) );
+
+                $username = wc_create_new_customer_username( $email );
+                $user_id  = wc_create_new_customer( $email, $username, null );
+
+                $customer = new WC_Customer( $user_id );
+                $this->maybe_update_billing_and_shipping( $customer, $session );
+
+                // Send a password reset link right away.
+                $user_data = get_user_by( 'ID', $user_id );
+
+                $key = get_password_reset_key( $user_data );
+
+                WC()->mailer();
+                do_action( 'woocommerce_reset_password_notification', $user_data->user_login, $key );
+
+                // Log the user in, if we have a valid session.
+                if ( WC()->session ) {
+                    wc_set_customer_auth_cookie( $user_id );
+                }
+            }
+
+            $order->set_customer_id( $user_id );
+            $order->save();
+        }
+
+        $this->maybe_update_billing_and_shipping( $order, $session );
+
+        // Update subscription with the correct customer id, and agreement id
+        $existing_subscriptions = wcs_get_subscriptions_for_order( $order );
+
+        /** @var WC_Subscription $subscription */
+        $subscription = array_pop( $existing_subscriptions );
+
+        if ( ! $subscription ) {
+            return;
+        }
+
+        WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_AGREEMENT_ID, $agreement_id );
+
+        $subscription->set_customer_id( $order->get_customer_id( 'edit' ) );
+        wcs_copy_order_address( $order, $subscription );
+        $subscription->save();
+
+        $this->gateway()->check_charge_status( $order_id, true );
+
+        // This is passed off to regular cron or API handling after this point
+        WC_Vipps_Recurring_Logger::log( sprintf( "[%s] Finished handling Vipps/MobilePay Checkout payment for agreement ID %s", $order_id, $agreement_id ) );
+    }
+
+    public function maybe_update_billing_and_shipping( $object, $session ): void {
+        $contact = $session['billingDetails'] ?? $session['shippingDetails'];
+
+        if ( empty( $contact ) ) {
+            return;
+        }
+
+        $object->set_billing_email( $contact['email'] );
+        $object->set_billing_phone( '+' . $contact['phoneNumber'] );
+        $object->set_billing_first_name( $contact['firstName'] );
+        $object->set_billing_last_name( $contact['lastName'] );
+        $object->set_billing_address_1( $contact['streetAddress'] );
+        $object->set_billing_city( $contact['city'] );
+        $object->set_billing_postcode( $contact['postalCode'] );
+        $object->set_billing_country( $contact['country'] );
+
+        if ( isset( $session['shippingDetails'] ) ) {
+            $contact = $session['shippingDetails'];
+        }
+
+        $object->set_shipping_first_name( $contact['firstName'] );
+        $object->set_shipping_last_name( $contact['lastName'] );
+        $object->set_shipping_address_1( $contact['streetAddress'] );
+        $object->set_shipping_city( $contact['city'] );
+        $object->set_shipping_postcode( $contact['postalCode'] );
+        $object->set_shipping_country( $contact['country'] );
+
+        $object->save();
+    }
+
+    public function maybe_cancel_initial_order( WC_Order $order ): void {
+        $created = $order->get_date_created();
+        $now     = time();
+
+        try {
+            $timestamp = $created->getTimestamp();
+        } catch ( Exception $e ) {
+            // PHP 8 gives ValueError for certain older versions of WooCommerce here.
+            $timestamp = intval( $created->format( 'U' ) );
+        }
+
+        $passed  = $now - $timestamp;
+        $minutes = ( $passed / 60 );
+
+        if ( $order->get_status() === 'pending' && $minutes > 120 ) {
+            $this->abandon_checkout_order( $order );
+        }
+    }
+
+    public function user_has_subscription( $has_subscription, $user_id, $product_id, $status ) {
+        $subscriptions = wcs_get_users_subscriptions( $user_id );
+
+        foreach ( $subscriptions as $subscription ) {
+            if ( ! WC_Vipps_Recurring_Helper::get_meta( $subscription, WC_Vipps_Recurring_Helper::META_ORDER_IS_CHECKOUT ) ) {
+                continue;
+            }
+
+            // You do not have a subscription simply because you have a pending subscription.
+            // Checkout subscriptions are created BEFORE a payment is made.
+            if ( $subscription->has_status( 'pending' ) ) {
+                $has_subscription = false;
+                break;
+            }
+        }
+
+        return $has_subscription;
+    }
 }

--- a/recurring/includes/wc-vipps-recurring.php
+++ b/recurring/includes/wc-vipps-recurring.php
@@ -705,11 +705,13 @@ class WC_Vipps_Recurring {
 
 		$options = [
 			'limit'          => $limit,
-			'type'           => 'shop_order',
-			'meta_key'       => WC_Vipps_Recurring_Helper::META_CHARGE_PENDING,
-			'meta_compare'   => '=',
-			'meta_value'     => 1,
-			'return'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => WC_Vipps_Recurring_Helper::META_CHARGE_PENDING,
+					'compare' => '=',
+					'value'   => 1
+				]
+			],
 			'payment_method' => $this->gateway()->id
 		];
 
@@ -721,15 +723,17 @@ class WC_Vipps_Recurring {
 		}
 
 		remove_all_filters( 'posts_orderby' );
-		$order_ids = wc_get_orders( $options );
+		$orders = wc_get_orders( $options );
 
-		foreach ( $order_ids as $order_id ) {
+		foreach ( $orders as $order ) {
+			$order_id = WC_Vipps_Recurring_Helper::get_id( $order );
+
 			do_action( 'wc_vipps_recurring_before_cron_check_order_status', $order_id );
 			$this->gateway()->check_charge_status( $order_id );
 			do_action( 'wc_vipps_recurring_after_cron_check_order_status', $order_id );
 		}
 
-		return $order_ids;
+		return $orders;
 	}
 
 	/**

--- a/recurring/includes/wc-vipps-recurring.php
+++ b/recurring/includes/wc-vipps-recurring.php
@@ -806,6 +806,10 @@ class WC_Vipps_Recurring {
 
             WC_Vipps_Recurring_Logger::log( sprintf( "Checking if order %s should be deleted (status: %s, empty email: %s, is renewal: %s).", WC_Vipps_Recurring_Helper::get_id( $order ), $order->get_status(), $empty_email ? 'Yes' : 'No', wcs_order_contains_renewal( $order ) ? 'Yes' : 'No' ) );
 
+            // Check the status of this order's charge for good measure.
+            $this->gateway()->check_charge_status( WC_Vipps_Recurring_Helper::get_id( $order ) );
+            $order = wc_get_order( $order );
+
             if ( ! in_array( $order->get_status( 'edit' ), [ 'pending', 'cancelled' ] ) || ! $empty_email ) {
                 WC_Vipps_Recurring_Logger::log( sprintf( "Removing %s from the deletion queue as it should no longer be deleted.", WC_Vipps_Recurring_Helper::get_id( $order ) ) );
 

--- a/recurring/includes/wc-vipps-recurring.php
+++ b/recurring/includes/wc-vipps-recurring.php
@@ -3,254 +3,254 @@
 defined( 'ABSPATH' ) || exit;
 
 class WC_Vipps_Recurring {
-	/**
-	 * The reference the *Singleton* instance of this class
-	 */
-	private static ?WC_Vipps_Recurring $instance = null;
+    /**
+     * The reference the *Singleton* instance of this class
+     */
+    private static ?WC_Vipps_Recurring $instance = null;
 
-	public WC_Vipps_Recurring_Admin_Notices $notices;
+    public WC_Vipps_Recurring_Admin_Notices $notices;
 
-	public array $ajax_config = [];
+    public array $ajax_config = [];
 
-	/**
-	 * Returns the *Singleton* instance of this class.
-	 *
-	 * @return WC_Vipps_Recurring
-	 */
-	public static function get_instance(): WC_Vipps_Recurring {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
+    /**
+     * Returns the *Singleton* instance of this class.
+     *
+     * @return WC_Vipps_Recurring
+     */
+    public static function get_instance(): WC_Vipps_Recurring {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
 
-		return self::$instance;
-	}
+        return self::$instance;
+    }
 
-	public static function register_hooks() {
-		$instance = WC_Vipps_Recurring::get_instance();
+    public static function register_hooks() {
+        $instance = WC_Vipps_Recurring::get_instance();
 
-		// No longer handled directly here
-		// register_activation_hook( WC_VIPPS_MAIN_FILE, [ $instance, 'activate' ] );
-		// register_deactivation_hook( WC_VIPPS_MAIN_FILE, [ $instance, 'deactivate' ] );
+        // No longer handled directly here
+        // register_activation_hook( WC_VIPPS_MAIN_FILE, [ $instance, 'activate' ] );
+        // register_deactivation_hook( WC_VIPPS_MAIN_FILE, [ $instance, 'deactivate' ] );
 
-		if ( is_admin() ) {
-			add_action( 'admin_init', [ $instance, 'admin_init' ] );
-			add_action( 'admin_menu', [ $instance, 'admin_menu' ] );
-			add_action( 'wp_ajax_vipps_recurring_force_check_charge_statuses', [
-				$instance,
-				'wp_ajax_vipps_recurring_force_check_charge_statuses'
-			] );
-		}
+        if ( is_admin() ) {
+            add_action( 'admin_init', [ $instance, 'admin_init' ] );
+            add_action( 'admin_menu', [ $instance, 'admin_menu' ] );
+            add_action( 'wp_ajax_vipps_recurring_force_check_charge_statuses', [
+                $instance,
+                'wp_ajax_vipps_recurring_force_check_charge_statuses'
+            ] );
+        }
 
-		add_action( 'plugins_loaded', [ $instance, 'plugins_loaded' ] );
-		// Declare compatibility with the WooCommerce checkout block
-		add_action( 'woocommerce_blocks_loaded', [ $instance, 'woocommerce_blocks_loaded' ] );
-		add_action( 'init', [ $instance, 'init' ] );
-	}
+        add_action( 'plugins_loaded', [ $instance, 'plugins_loaded' ] );
+        // Declare compatibility with the WooCommerce checkout block
+        add_action( 'woocommerce_blocks_loaded', [ $instance, 'woocommerce_blocks_loaded' ] );
+        add_action( 'init', [ $instance, 'init' ] );
+    }
 
-	public function activate() {
-		global $wp_rewrite;
+    public function activate() {
+        global $wp_rewrite;
 
-		$this->install();
+        $this->install();
 
-		$wp_rewrite->flush_rules();
-		add_option( 'woo-vipps-recurring-version', WC_VIPPS_RECURRING_VERSION );
-	}
+        $wp_rewrite->flush_rules();
+        add_option( 'woo-vipps-recurring-version', WC_VIPPS_RECURRING_VERSION );
+    }
 
-	/**
-	 * Private clone method to prevent cloning of the instance of the
-	 * *Singleton* instance.
-	 *
-	 * @return void
-	 */
-	private function __clone() {
-	}
+    /**
+     * Private clone method to prevent cloning of the instance of the
+     * *Singleton* instance.
+     *
+     * @return void
+     */
+    private function __clone() {
+    }
 
-	/**
-	 * Private un-serialize method to prevent un-serializing of the *Singleton*
-	 * instance.
-	 *
-	 * @return void
-	 */
-	public function __wakeup() {
-	}
+    /**
+     * Private un-serialize method to prevent un-serializing of the *Singleton*
+     * instance.
+     *
+     * @return void
+     */
+    public function __wakeup() {
+    }
 
-	/**
-	 * Protected constructor to prevent creating a new instance of the
-	 * *Singleton* via the `new` operator from outside of this class.
-	 */
-	private function __construct() {
-	}
+    /**
+     * Protected constructor to prevent creating a new instance of the
+     * *Singleton* via the `new` operator from outside of this class.
+     */
+    private function __construct() {
+    }
 
-	/**
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 */
-	public static function deactivate() {
-		WC_Vipps_Recurring::get_instance()->gateway()->webhook_teardown();
-	}
+    /**
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     * @throws WC_Vipps_Recurring_Config_Exception
+     */
+    public static function deactivate() {
+        WC_Vipps_Recurring::get_instance()->gateway()->webhook_teardown();
+    }
 
-	public function plugins_loaded() {
-		add_filter( 'woocommerce_payment_gateways', [ $this, 'add_gateways' ] );
+    public function plugins_loaded() {
+        add_filter( 'woocommerce_payment_gateways', [ $this, 'add_gateways' ] );
 
-		// Add custom product settings for Vipps Recurring.
-		add_filter( 'woocommerce_product_data_tabs', [ $this, 'woocommerce_product_data_tabs' ] );
-		add_filter( 'woocommerce_product_data_panels', [ $this, 'woocommerce_product_data_panels' ] );
-		add_filter( 'woocommerce_process_product_meta', [ $this, 'woocommerce_process_product_meta' ] );
+        // Add custom product settings for Vipps Recurring.
+        add_filter( 'woocommerce_product_data_tabs', [ $this, 'woocommerce_product_data_tabs' ] );
+        add_filter( 'woocommerce_product_data_panels', [ $this, 'woocommerce_product_data_panels' ] );
+        add_filter( 'woocommerce_process_product_meta', [ $this, 'woocommerce_process_product_meta' ] );
 
-		// Disable this gateway unless we're purchasing at least one subscription product.
-		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'maybe_disable_gateway' ] );
+        // Disable this gateway unless we're purchasing at least one subscription product.
+        add_filter( 'woocommerce_available_payment_gateways', [ $this, 'maybe_disable_gateway' ] );
 
-		add_action( 'woocommerce_api_wc_gateway_vipps_recurring', [ $this, 'handle_webhook_callback' ] );
+        add_action( 'woocommerce_api_wc_gateway_vipps_recurring', [ $this, 'handle_webhook_callback' ] );
 
-		// Create a real page for Vipps Checkout
-		add_filter( 'woocommerce_create_pages', [ $this, 'woocommerce_create_pages' ], 50 );
+        // Create a real page for Vipps Checkout
+        add_filter( 'woocommerce_create_pages', [ $this, 'woocommerce_create_pages' ], 50 );
 
-	}
+    }
 
-	// Runs possibly before plugins_loaded
-	public function woocommerce_blocks_loaded() {
-		if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
-			require_once 'wc-vipps-recurring-blocks-support.php';
-			add_action(
-				'woocommerce_blocks_payment_method_type_registration',
-				function ( Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry ) {
-					$payment_method_registry->register( new WC_Vipps_Recurring_Blocks_Support() );
-				}
-			);
-		}
-	}
+    // Runs possibly before plugins_loaded
+    public function woocommerce_blocks_loaded() {
+        if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
+            require_once 'wc-vipps-recurring-blocks-support.php';
+            add_action(
+                'woocommerce_blocks_payment_method_type_registration',
+                function ( Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry ) {
+                    $payment_method_registry->register( new WC_Vipps_Recurring_Blocks_Support() );
+                }
+            );
+        }
+    }
 
-	/**
-	 * Init the plugin after plugins_loaded so environment variables are set.
-	 *
-	 * @since 1.0.0
-	 * @version 4.0.0
-	 */
-	public function init() {
-		require_once __DIR__ . '/wc-vipps-recurring-rest-api.php';
-		WC_Vipps_Recurring_Rest_Api::get_instance();
+    /**
+     * Init the plugin after plugins_loaded so environment variables are set.
+     *
+     * @since 1.0.0
+     * @version 4.0.0
+     */
+    public function init() {
+        require_once __DIR__ . '/wc-vipps-recurring-rest-api.php';
+        WC_Vipps_Recurring_Rest_Api::get_instance();
 
-		$this->notices = WC_Vipps_Recurring_Admin_Notices::get_instance( WC_VIPPS_RECURRING_MAIN_FILE );
+        $this->notices = WC_Vipps_Recurring_Admin_Notices::get_instance( WC_VIPPS_RECURRING_MAIN_FILE );
 
-		add_action( 'wp_enqueue_scripts', [ $this, 'wp_enqueue_scripts' ] );
+        add_action( 'wp_enqueue_scripts', [ $this, 'wp_enqueue_scripts' ] );
 
-		add_filter( 'plugin_action_links_' . plugin_basename( WC_VIPPS_MAIN_FILE ), [
-			$this,
-			'plugin_action_links'
-		] );
+        add_filter( 'plugin_action_links_' . plugin_basename( WC_VIPPS_MAIN_FILE ), [
+            $this,
+            'plugin_action_links'
+        ] );
 
-		// Add custom cron schedules for Vipps/MobilePay charge polling
-		add_filter( 'cron_schedules', [
-			$this,
-			'woocommerce_vipps_recurring_add_cron_schedules'
-		] );
+        // Add custom cron schedules for Vipps/MobilePay charge polling
+        add_filter( 'cron_schedules', [
+            $this,
+            'woocommerce_vipps_recurring_add_cron_schedules'
+        ] );
 
-		// schedule recurring payment charge status checking event
-		if ( ! wp_next_scheduled( 'woocommerce_vipps_recurring_check_order_statuses' ) ) {
-			wp_schedule_event( time(), 'one_minute', 'woocommerce_vipps_recurring_check_order_statuses' );
-		}
+        // schedule recurring payment charge status checking event
+        if ( ! wp_next_scheduled( 'woocommerce_vipps_recurring_check_order_statuses' ) ) {
+            wp_schedule_event( time(), 'one_minute', 'woocommerce_vipps_recurring_check_order_statuses' );
+        }
 
-		add_action( 'woocommerce_vipps_recurring_check_order_statuses', [
-			$this,
-			'check_order_statuses'
-		] );
+        add_action( 'woocommerce_vipps_recurring_check_order_statuses', [
+            $this,
+            'check_order_statuses'
+        ] );
 
-		// Schedule checking if gateway change went through
-		if ( ! wp_next_scheduled( 'woocommerce_vipps_recurring_check_gateway_change_request' ) ) {
-			wp_schedule_event( time(), 'one_minute', 'woocommerce_vipps_recurring_check_gateway_change_request' );
-		}
+        // Schedule checking if gateway change went through
+        if ( ! wp_next_scheduled( 'woocommerce_vipps_recurring_check_gateway_change_request' ) ) {
+            wp_schedule_event( time(), 'one_minute', 'woocommerce_vipps_recurring_check_gateway_change_request' );
+        }
 
-		add_action( 'woocommerce_vipps_recurring_check_gateway_change_request', [
-			$this,
-			'check_gateway_change_agreement_statuses'
-		] );
+        add_action( 'woocommerce_vipps_recurring_check_gateway_change_request', [
+            $this,
+            'check_gateway_change_agreement_statuses'
+        ] );
 
-		// Schedule checking for updating payment details
-		if ( ! wp_next_scheduled( 'woocommerce_vipps_recurring_update_subscription_details_in_app' ) ) {
-			wp_schedule_event( time(), 'one_minute', 'woocommerce_vipps_recurring_update_subscription_details_in_app' );
-		}
+        // Schedule checking for updating payment details
+        if ( ! wp_next_scheduled( 'woocommerce_vipps_recurring_update_subscription_details_in_app' ) ) {
+            wp_schedule_event( time(), 'one_minute', 'woocommerce_vipps_recurring_update_subscription_details_in_app' );
+        }
 
-		add_action( 'woocommerce_vipps_recurring_update_subscription_details_in_app', [
-			$this,
-			'update_subscription_details_in_app'
-		] );
+        add_action( 'woocommerce_vipps_recurring_update_subscription_details_in_app', [
+            $this,
+            'update_subscription_details_in_app'
+        ] );
 
-		// Schedule cleaning up orders that are marked for deletion
-		if ( ! wp_next_scheduled( 'woocommerce_vipps_recurring_check_orders_marked_for_deletion' ) ) {
-			wp_schedule_event( time(), 'hourly', 'woocommerce_vipps_recurring_check_orders_marked_for_deletion' );
-		}
+        // Schedule cleaning up orders that are marked for deletion
+        if ( ! wp_next_scheduled( 'woocommerce_vipps_recurring_check_orders_marked_for_deletion' ) ) {
+            wp_schedule_event( time(), 'hourly', 'woocommerce_vipps_recurring_check_orders_marked_for_deletion' );
+        }
 
-		add_action( 'woocommerce_vipps_recurring_check_orders_marked_for_deletion', [
-			$this,
-			'check_orders_marked_for_deletion'
-		] );
+        add_action( 'woocommerce_vipps_recurring_check_orders_marked_for_deletion', [
+            $this,
+            'check_orders_marked_for_deletion'
+        ] );
 
-		// Add our own ajax actions
-		add_action( 'wp_ajax_wc_vipps_recurring_order_action', [
-			$this,
-			'order_handle_vipps_recurring_action'
-		] );
+        // Add our own ajax actions
+        add_action( 'wp_ajax_wc_vipps_recurring_order_action', [
+            $this,
+            'order_handle_vipps_recurring_action'
+        ] );
 
-		// Custom actions
-		add_filter( 'generate_rewrite_rules', [ $this, 'custom_action_endpoints' ] );
-		add_filter( 'query_vars', [ $this, 'custom_action_query_vars' ] );
-		add_filter( 'template_include', [ $this, 'custom_action_page_template' ] );
-	}
+        // Custom actions
+        add_filter( 'generate_rewrite_rules', [ $this, 'custom_action_endpoints' ] );
+        add_filter( 'query_vars', [ $this, 'custom_action_query_vars' ] );
+        add_filter( 'template_include', [ $this, 'custom_action_page_template' ] );
+    }
 
-	/**
-	 * Admin only dashboard
-	 */
-	public function admin_init() {
-		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
+    /**
+     * Admin only dashboard
+     */
+    public function admin_init() {
+        add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 
-		add_action( 'admin_head', [ $this, 'admin_head' ] );
+        add_action( 'admin_head', [ $this, 'admin_head' ] );
 
-		if ( ! class_exists( 'WC_Subscriptions' ) ) {
-			// translators: %s link to WooCommerce Subscription's purchase page
-			$notice = sprintf( esc_html__( 'Vipps/MobilePay Recurring Payments requires WooCommerce Subscriptions to be installed and active. You can purchase and download %s here.', 'woo-vipps' ), '<a href="https://woocommerce.com/products/woocommerce-subscriptions/" target="_blank">WooCommerce Subscriptions</a>' );
-			$this->notices->error( $notice );
+        if ( ! class_exists( 'WC_Subscriptions' ) ) {
+            // translators: %s link to WooCommerce Subscription's purchase page
+            $notice = sprintf( esc_html__( 'Vipps/MobilePay Recurring Payments requires WooCommerce Subscriptions to be installed and active. You can purchase and download %s here.', 'woo-vipps' ), '<a href="https://woocommerce.com/products/woocommerce-subscriptions/" target="_blank">WooCommerce Subscriptions</a>' );
+            $this->notices->error( $notice );
 
-			return;
-		}
+            return;
+        }
 
-		// Add capture button if order is not captured
-		add_action( 'woocommerce_order_item_add_action_buttons', [
-			$this,
-			'order_item_add_action_buttons'
-		] );
+        // Add capture button if order is not captured
+        add_action( 'woocommerce_order_item_add_action_buttons', [
+            $this,
+            'order_item_add_action_buttons'
+        ] );
 
-		if ( $this->gateway()->test_mode ) {
-			$notice = __( 'Vipps/MobilePay Recurring Payments is currently in test mode - no real transactions will occur. Disable test mode when you are ready to go live!', 'woo-vipps' );
-			$this->notices->warning( $notice );
-		}
+        if ( $this->gateway()->test_mode ) {
+            $notice = __( 'Vipps/MobilePay Recurring Payments is currently in test mode - no real transactions will occur. Disable test mode when you are ready to go live!', 'woo-vipps' );
+            $this->notices->warning( $notice );
+        }
 
-		// Load correct list table classes for current screen.
-		add_action( 'current_screen', [ $this, 'setup_screen' ] );
+        // Load correct list table classes for current screen.
+        add_action( 'current_screen', [ $this, 'setup_screen' ] );
 
-		if ( isset( $_REQUEST['statuses_checked'] ) ) {
-			$this->notices->success( __( 'Successfully checked the status of these charges', 'woo-vipps' ) );
-		}
+        if ( isset( $_REQUEST['statuses_checked'] ) ) {
+            $this->notices->success( __( 'Successfully checked the status of these charges', 'woo-vipps' ) );
+        }
 
-		// Initialize webhooks if we haven't already
-		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
-			if ( WC_Vipps_Recurring_Helper::is_connected() ) {
-				if ( empty( get_option( WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS ) ) ) {
-					$this->gateway()->webhook_initialize();
-				} else {
-					$ok = $this->gateway()->webhook_ensure_this_site();
+        // Initialize webhooks if we haven't already
+        if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
+            if ( WC_Vipps_Recurring_Helper::is_connected() ) {
+                if ( empty( get_option( WC_Vipps_Recurring_Helper::OPTION_WEBHOOKS ) ) ) {
+                    $this->gateway()->webhook_initialize();
+                } else {
+                    $ok = $this->gateway()->webhook_ensure_this_site();
 
-					if ( ! $ok ) {
-						$this->gateway()->webhook_initialize();
-					}
-				}
-			}
-		}
+                    if ( ! $ok ) {
+                        $this->gateway()->webhook_initialize();
+                    }
+                }
+            }
+        }
 
 //		$test = $this->gateway()->check_charge_status(931);
 
-		// Show Vipps Login notice for a maximum of 10 days
-		// 1636066799 = 04-11-2021 23:59:59 UTC
+        // Show Vipps Login notice for a maximum of 10 days
+        // 1636066799 = 04-11-2021 23:59:59 UTC
 //				if ( ! class_exists( 'VippsWooLogin' ) && time() < 1636066799 ) {
 //					$vipps_login_plugin_url = 'https://wordpress.org/plugins/login-with-vipps';
 //					if ( get_locale() === 'nb_NO' ) {
@@ -266,25 +266,25 @@ class WC_Vipps_Recurring {
 //						'login-promotion'
 //					);
 //				}
-	}
+    }
 
-	public function gateway(): WC_Gateway_Vipps_Recurring {
-		require_once( "wc-gateway-vipps-recurring.php" );
+    public function gateway(): WC_Gateway_Vipps_Recurring {
+        require_once( "wc-gateway-vipps-recurring.php" );
 
-		return WC_Gateway_Vipps_Recurring::get_instance();
-	}
+        return WC_Gateway_Vipps_Recurring::get_instance();
+    }
 
-	/**
-	 * Upgrade routines
-	 */
-	public function upgrade() {
-		global $wpdb, $wp_rewrite;
+    /**
+     * Upgrade routines
+     */
+    public function upgrade() {
+        global $wpdb, $wp_rewrite;
 
-		$version = get_option( 'woo-vipps-recurring-version' );
+        $version = get_option( 'woo-vipps-recurring-version' );
 
-		// Update 1.8.1: add back _vipps_recurring_pending_charge and _charge_id
-		if ( version_compare( $version, '1.8.1', '<' ) ) {
-			$results = $wpdb->get_results( "SELECT wp_posts.id FROM (
+        // Update 1.8.1: add back _vipps_recurring_pending_charge and _charge_id
+        if ( version_compare( $version, '1.8.1', '<' ) ) {
+            $results = $wpdb->get_results( "SELECT wp_posts.id FROM (
 						SELECT DISTINCT post_id as id FROM wp_postmeta as m
 						WHERE EXISTS (SELECT * FROM wp_postmeta WHERE post_id = m.post_id AND meta_key = '_vipps_recurring_failed_charge_reason')
 						AND NOT EXISTS (SELECT * FROM wp_postmeta WHERE post_id = m.post_id AND meta_key = '_vipps_recurring_pending_charge')
@@ -292,20 +292,20 @@ class WC_Vipps_Recurring {
 					JOIN wp_posts ON (wp_posts.id = lookup.id)
 					ORDER BY wp_posts.post_date DESC", ARRAY_A );
 
-			WC_Vipps_Recurring_Logger::log( sprintf( 'Running 1.8.1 update, affecting orders with IDs: %s', implode( ',', array_map( function ( $item ) {
-				return $item['id'];
-			}, $results ) ) ) );
+            WC_Vipps_Recurring_Logger::log( sprintf( 'Running 1.8.1 update, affecting orders with IDs: %s', implode( ',', array_map( function ( $item ) {
+                return $item['id'];
+            }, $results ) ) ) );
 
-			foreach ( $results as $row ) {
-				$order = wc_get_order( $row['id'] );
-				WC_Vipps_Recurring_Helper::set_order_charge_not_failed( $order, WC_Vipps_Recurring_Helper::get_transaction_id_for_order( $order ) );
-				$order->save();
-			}
-		}
+            foreach ( $results as $row ) {
+                $order = wc_get_order( $row['id'] );
+                WC_Vipps_Recurring_Helper::set_order_charge_not_failed( $order, WC_Vipps_Recurring_Helper::get_transaction_id_for_order( $order ) );
+                $order->save();
+            }
+        }
 
-		// Update 1.8.2: migrate failed statuses to subscription too
-		if ( version_compare( $version, '1.8.2', '<' ) ) {
-			$results = $wpdb->get_results( "SELECT wp_posts.id
+        // Update 1.8.2: migrate failed statuses to subscription too
+        if ( version_compare( $version, '1.8.2', '<' ) ) {
+            $results = $wpdb->get_results( "SELECT wp_posts.id
 						FROM (
 						         SELECT DISTINCT post_id as id
 						         FROM wp_postmeta as m
@@ -317,750 +317,750 @@ class WC_Vipps_Recurring {
 						         JOIN wp_posts ON (wp_posts.id = lookup.id)
 						ORDER BY wp_posts.post_date DESC", ARRAY_A );
 
-			WC_Vipps_Recurring_Logger::log( sprintf( 'Running 1.8.2 update, affecting orders with IDs: %s', implode( ',', array_map( function ( $item ) {
-				return $item['id'];
-			}, $results ) ) ) );
+            WC_Vipps_Recurring_Logger::log( sprintf( 'Running 1.8.2 update, affecting orders with IDs: %s', implode( ',', array_map( function ( $item ) {
+                return $item['id'];
+            }, $results ) ) ) );
 
-			foreach ( $results as $row ) {
-				$order = wc_get_order( $row['id'] );
+            foreach ( $results as $row ) {
+                $order = wc_get_order( $row['id'] );
 
-				$subscriptions = WC_Vipps_Recurring_Helper::get_subscriptions_for_order( $order );
-				$subscription  = $subscriptions[ array_key_first( $subscriptions ) ];
+                $subscriptions = WC_Vipps_Recurring_Helper::get_subscriptions_for_order( $order );
+                $subscription  = $subscriptions[ array_key_first( $subscriptions ) ];
 
-				if ( ! $subscription ) {
-					continue;
-				}
+                if ( ! $subscription ) {
+                    continue;
+                }
 
-				$failure_reason = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_FAILED_REASON );
-				if ( $failure_reason ) {
-					WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_LATEST_FAILED_CHARGE_REASON, $failure_reason );
-				}
+                $failure_reason = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_FAILED_REASON );
+                if ( $failure_reason ) {
+                    WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_LATEST_FAILED_CHARGE_REASON, $failure_reason );
+                }
 
-				$failure_description = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_FAILED_DESCRIPTION );
-				if ( $failure_description ) {
-					WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_LATEST_FAILED_CHARGE_DESCRIPTION, $failure_description );
-				}
+                $failure_description = WC_Vipps_Recurring_Helper::get_meta( $order, WC_Vipps_Recurring_Helper::META_CHARGE_FAILED_DESCRIPTION );
+                if ( $failure_description ) {
+                    WC_Vipps_Recurring_Helper::update_meta_data( $subscription, WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_LATEST_FAILED_CHARGE_DESCRIPTION, $failure_description );
+                }
 
-				$subscription->save();
-			}
-		}
+                $subscription->save();
+            }
+        }
 
-		// Flush permalinks when updating to version 1.20.2
-		if ( version_compare( $version, '1.20.2', '<' ) ) {
-			$wp_rewrite->flush_rules();
-		}
+        // Flush permalinks when updating to version 1.20.2
+        if ( version_compare( $version, '1.20.2', '<' ) ) {
+            $wp_rewrite->flush_rules();
+        }
 
-		// Copy MSN, client id, client secret and subscription key to our new test fields if test mode is enabled.
-		if ( $this->gateway()->test_mode && version_compare( $version, '2.0.0', '<' ) ) {
-			$this->gateway()->update_option( 'test_merchant_serial_number', $this->gateway()->get_option( 'merchant_serial_number' ) );
-			$this->gateway()->update_option( 'test_client_id', $this->gateway()->get_option( 'client_id' ) );
-			$this->gateway()->update_option( 'test_secret_key', $this->gateway()->get_option( 'secret_key' ) );
-			$this->gateway()->update_option( 'test_subscription_key', $this->gateway()->get_option( 'subscription_key' ) );
-		}
+        // Copy MSN, client id, client secret and subscription key to our new test fields if test mode is enabled.
+        if ( $this->gateway()->test_mode && version_compare( $version, '2.0.0', '<' ) ) {
+            $this->gateway()->update_option( 'test_merchant_serial_number', $this->gateway()->get_option( 'merchant_serial_number' ) );
+            $this->gateway()->update_option( 'test_client_id', $this->gateway()->get_option( 'client_id' ) );
+            $this->gateway()->update_option( 'test_secret_key', $this->gateway()->get_option( 'secret_key' ) );
+            $this->gateway()->update_option( 'test_subscription_key', $this->gateway()->get_option( 'subscription_key' ) );
+        }
 
-		if ( $version !== WC_VIPPS_RECURRING_VERSION ) {
-			update_option( 'woo-vipps-recurring-version', WC_VIPPS_RECURRING_VERSION );
-		}
-	}
+        if ( $version !== WC_VIPPS_RECURRING_VERSION ) {
+            update_option( 'woo-vipps-recurring-version', WC_VIPPS_RECURRING_VERSION );
+        }
+    }
 
-	/**
-	 * Inject admin ahead
-	 */
-	public function admin_head() {
-		$icon = plugins_url( 'assets/images/' . $this->gateway()->brand . '-mark-icon.svg', WC_VIPPS_RECURRING_MAIN_FILE );
+    /**
+     * Inject admin ahead
+     */
+    public function admin_head() {
+        $icon = plugins_url( 'assets/images/' . $this->gateway()->brand . '-mark-icon.svg', WC_VIPPS_RECURRING_MAIN_FILE );
 
-		?>
+        ?>
         <style>
             #woocommerce-product-data ul.wc-tabs li.wc_vipps_recurring_options a:before {
                 background-image: url( <?php echo $icon ?> );
             }
         </style>
-		<?php
-	}
+        <?php
+    }
 
-	public function gateway_should_be_active( array $methods = [] ) {
-		// The only two reasons to not show our gateway is if the cart supports being purchased by the standard Vipps MobilePay gateway
-		// Or if the cart does not contain a subscription product
-		$active = ! isset( $methods['vipps'] )
-		          && ( WC_Subscriptions_Cart::cart_contains_subscription()
+    public function gateway_should_be_active( array $methods = [] ) {
+        // The only two reasons to not show our gateway is if the cart supports being purchased by the standard Vipps MobilePay gateway
+        // Or if the cart does not contain a subscription product
+        $active = ! isset( $methods['vipps'] )
+                  && ( WC_Subscriptions_Cart::cart_contains_subscription()
                        || wcs_cart_contains_switches()
                        || wcs_cart_contains_failed_renewal_order_payment()
                        || isset( $_GET['change_payment_method'] ) );
 
-		return apply_filters( 'wc_vipps_recurring_cart_has_subscription_product', $active, WC()->cart->get_cart_contents() );
-	}
-
-	public function maybe_disable_gateway( $methods ) {
-		if ( is_admin() || ! is_checkout() ) {
-			return $methods;
-		}
-
-		$show_gateway = $this->gateway_should_be_active( $methods );
-
-		if ( ! $show_gateway ) {
-			unset( $methods['vipps_recurring'] );
-		}
-
-		return $methods;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function handle_check_statuses_bulk_action(): string {
-		$sendback = remove_query_arg( [ 'orders' ], wp_get_referer() );
-
-		if ( isset( $_GET['orders'] ) ) {
-			$order_ids = $_GET['orders'];
-
-			foreach ( $order_ids as $order_id ) {
-				// check charge status
-				$this->gateway()->check_charge_status( $order_id, true );
-			}
-
-			$sendback = add_query_arg( 'statuses_checked', 1, $sendback );
-		}
-
-		return $sendback;
-	}
-
-	/**
-	 * Setup the screen for our special setting and action tables
-	 */
-	public function setup_screen() {
-		global $wc_vipps_recurring_list_table_pending_charges,
-		       $wc_vipps_recurring_list_table_failed_charges;
-
-		$screen_id = false;
-
-		if ( function_exists( 'get_current_screen' ) ) {
-			$screen    = get_current_screen();
-			$screen_id = isset( $screen, $screen->id ) ? $screen->id : '';
-		}
-
-		if ( ! empty( $_REQUEST['screen'] ) ) {
-			$screen_id = wc_clean( wp_unslash( $_REQUEST['screen'] ) );
-		}
-
-		if ( $screen_id === 'settings_page_woo-vipps-recurring' ) {
-			include_once 'admin/list-tables/wc-vipps-recurring-list-table-pending-charges.php';
-			include_once 'admin/list-tables/wc-vipps-recurring-list-table-failed-charges.php';
-
-			$wc_vipps_recurring_list_table_pending_charges = new WC_Vipps_Recurring_Admin_List_Pending_Charges( [
-				'screen' => $screen_id . '_pending-charges'
-			] );
-			$wc_vipps_recurring_list_table_failed_charges  = new WC_Vipps_Recurring_Admin_List_Failed_Charges( [
-				'screen' => $screen_id . '_failed-charges'
-			] );
-		}
-
-		if ( $wc_vipps_recurring_list_table_pending_charges
-		     && $wc_vipps_recurring_list_table_pending_charges->current_action()
-		     && $wc_vipps_recurring_list_table_pending_charges->current_action() === 'check_status' ) {
-			$sendback = $this->handle_check_statuses_bulk_action();
-
-			wp_redirect( $sendback );
-		}
-
-		if ( $wc_vipps_recurring_list_table_failed_charges
-		     && $wc_vipps_recurring_list_table_failed_charges->current_action()
-		     && $wc_vipps_recurring_list_table_failed_charges->current_action() === 'check_status' ) {
-			$sendback = $this->handle_check_statuses_bulk_action();
-
-			wp_redirect( $sendback );
-		}
-
-		// Ensure the table handler is only loaded once. Prevents multiple loads if a plugin calls check_ajax_referer many times.
-		remove_action( 'current_screen', [ $this, 'setup_screen' ] );
-	}
-
-	/**
-	 * Make admin menu entry
-	 */
-	public function admin_menu() {
-		add_options_page(
-			__( 'Vipps/MobilePay Recurring Payments', 'woo-vipps' ),
-			__( 'Vipps/MobilePay Recurring Payments', 'woo-vipps' ),
-			'manage_options',
-			'woo-vipps-recurring',
-			[ $this, 'admin_menu_page_html' ]
-		);
-	}
-
-	/**
-	 * Admin menu page HTML
-	 */
-	public function admin_menu_page_html() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-
-		include __DIR__ . '/pages/admin/vipps-recurring-admin-menu-page.php';
-	}
-
-	public function custom_action_endpoints( $rewrites ) {
-		$rewrites->rules = array_merge(
-			[ 'vipps-mobilepay-recurring-payment/?$' => 'index.php?vipps_recurring_action=payment-redirect' ],
-			$rewrites->rules
-		);
-
-		return $rewrites;
-	}
-
-	public function custom_action_query_vars( $query_vars ) {
-		$query_vars[] = 'vipps_recurring_action';
-
-		return $query_vars;
-	}
-
-	public function custom_action_page_template( $original_template ) {
-		$custom_action = get_query_var( 'vipps_recurring_action' );
-
-		if ( ! empty ( $custom_action ) ) {
-			include WC_VIPPS_RECURRING_PLUGIN_PATH . '/includes/pages/payment-redirect-page.php';
-			die;
-		}
-
-		return $original_template;
-	}
-
-	public function maybe_create_checkout_page() {
-		$checkout_page_id    = wc_get_page_id( 'vipps_mobilepay_recurring_checkout' );
-		$should_create_pages = ! $checkout_page_id || ! get_post_status( $checkout_page_id );
-
-		if ( ! $should_create_pages ) {
-			return;
-		}
-
-		// Piggybacks off of WooCommerce's default logic for creating the checkout page.
-		// This is possible because we override the shortcode.
-		delete_option( 'woocommerce_vipps_recurring_checkout_page_id' );
-		WC_Install::create_pages();
-	}
-
-	/**
-	 * Vipps Checkout replaces the default checkout page, and currently uses its own page for this which needs to exist
-	 */
-	public function woocommerce_create_pages( $data ) {
-		$checkout_enabled = get_option( WC_Vipps_Recurring_Helper::OPTION_CHECKOUT_ENABLED, false );
-		if ( ! $checkout_enabled ) {
-			return $data;
-		}
-
-		$data['vipps_recurring_checkout'] = array(
-			'name'    => _x( 'vipps_recurring_checkout', 'Page slug', 'woo-vipps' ),
-			'title'   => _x( 'Vipps MobilePay Recurring Checkout', 'Page title', 'woo-vipps' ),
-			'content' => '<!-- wp:shortcode -->[' . 'vipps_recurring_checkout' . ']<!-- /wp:shortcode -->',
-		);
-
-		return $data;
-	}
-
-	/**
-	 * Force check status of all pending charges
-	 */
-	public function wp_ajax_vipps_recurring_force_check_charge_statuses(): void {
-		try {
-			/* translators: amount of orders checked */
-			echo sprintf( __( 'Done. Checked the status of %s orders', 'woo-vipps' ), count( $this->check_order_statuses( - 1 ) ) );
-		} catch ( Exception $e ) {
-			echo __( 'Failed to finish checking the status of all orders. Please try again.', 'woo-vipps' );
-		}
-
-		wp_die();
-	}
-
-	/**
-	 * @param $tabs
-	 *
-	 * @return mixed
-	 */
-	public function woocommerce_product_data_tabs( $tabs ) {
-		$tabs['wc_vipps_recurring'] = [
-			'label'    => __( 'Vipps/MobilePay Recurring Payments', 'woo-vipps' ),
-			'target'   => 'wc_vipps_recurring_product_data',
-			'priority' => 100,
-		];
-
-		return $tabs;
-	}
-
-	/**
-	 * Tab content
-	 */
-	public function woocommerce_product_data_panels(): void {
-		echo '<div id="wc_vipps_recurring_product_data" class="panel woocommerce_options_panel hidden">';
-
-		woocommerce_wp_checkbox( [
-			'id'          => WC_Vipps_Recurring_Helper::META_PRODUCT_DIRECT_CAPTURE,
-			'value'       => get_post_meta( get_the_ID(), WC_Vipps_Recurring_Helper::META_PRODUCT_DIRECT_CAPTURE, true ),
-			'label'       => __( 'Capture payment instantly', 'woo-vipps' ),
-			'description' => __( 'Capture payment instantly even if the product is not virtual. Please make sure you are following the local jurisdiction in your country when using this option.', 'woo-vipps' ),
-			'desc_tip'    => true,
-		] );
-
-		woocommerce_wp_select( [
-			'id'          => WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_SOURCE,
-			'value'       => get_post_meta( get_the_ID(), WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_SOURCE, true ) ?: 'title',
-			'label'       => __( 'Description source', 'woo-vipps' ),
-			'description' => __( 'Where we should source the agreement description from. Displayed in the Vipps/MobilePay app.', 'woo-vipps' ),
-			'desc_tip'    => true,
-			'options'     => [
-				'none'              => __( 'None', 'woo-vipps' ),
-				'short_description' => __( 'Product short description', 'woo-vipps' ),
-				'custom'            => __( 'Custom', 'woo-vipps' )
-			]
-		] );
-
-		woocommerce_wp_text_input( [
-			'id'          => WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_TEXT,
-			'value'       => get_post_meta( get_the_ID(), WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_TEXT, true ),
-			'label'       => __( 'Custom description', 'woo-vipps' ),
-			'description' => __( 'If the description source is set to "custom" this text will be used.', 'woo-vipps' ),
-			'placeholder' => __( 'Max 100 characters', 'woo-vipps' ),
-			'desc_tip'    => true,
-		] );
-
-		echo '</div>';
-	}
-
-	/**
-	 * Save our custom fields
-	 *
-	 * @param $post_id
-	 */
-	public function woocommerce_process_product_meta( $post_id ) {
-		$capture_instantly = isset( $_POST[ WC_Vipps_Recurring_Helper::META_PRODUCT_DIRECT_CAPTURE ] ) ? 'yes' : 'no';
-		update_post_meta( $post_id, WC_Vipps_Recurring_Helper::META_PRODUCT_DIRECT_CAPTURE, $capture_instantly );
-
-		update_post_meta( $post_id, WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_SOURCE, $_POST[ WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_SOURCE ] );
-		update_post_meta( $post_id, WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_TEXT, $_POST[ WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_TEXT ] ?? '' );
-	}
-
-	/**
-	 * @param $order
-	 */
-	public function order_item_add_action_buttons( $order ): void {
-		$this->order_item_add_capture_button( $order );
-	}
-
-	/**
-	 * @param $order
-	 */
-	public function order_item_add_capture_button( $order ): void {
-		if ( $order->get_type() !== 'shop_order' ) {
-			return;
-		}
-
-		$payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $order );
-		if ( $payment_method !== $this->gateway()->id ) {
-			// If this is not the payment method, an agreement would not be available.
-			return;
-		}
-
-		$show_capture_button = WC_Vipps_Recurring_Helper::can_capture_charge_for_order( $order );
-
-		if ( ! apply_filters( 'wc_vipps_recurring_show_capture_button', $show_capture_button, $order ) ) {
-			return;
-		}
-
-		$is_captured = WC_Vipps_Recurring_Helper::is_charge_captured_for_order( $order );
-
-		if ( $show_capture_button && ! $is_captured ) {
-			$logo = plugins_url( 'assets/images/' . $this->gateway()->brand . '-logo-white.svg', WC_VIPPS_RECURRING_MAIN_FILE );
-
-			print '<button type="button" data-order-id="' . $order->get_id() . '" data-action="capture_payment" class="button generate-items capture-payment-button ' . $this->gateway()->brand . '"><img border="0" style="display:inline;height:2ex;vertical-align:text-bottom" class="inline" alt="0" src="' . $logo . '"/> ' . __( 'Capture payment', 'woo-vipps' ) . '</button>';
-		}
-	}
-
-	public function order_handle_vipps_recurring_action() {
-		check_ajax_referer( 'vipps_recurring_ajax_nonce', 'nonce' );
-
-		$order = wc_get_order( intval( $_REQUEST['orderId'] ) );
-		if ( ! is_a( $order, 'WC_Order' ) ) {
-			return;
-		}
-
-		if ( $order->get_payment_method() != $this->gateway()->id ) {
-			return;
-		}
-
-		$action = isset( $_REQUEST['do'] ) ? sanitize_title( $_REQUEST['do'] ) : 'none';
-
-		if ( $action == 'capture_payment' ) {
-			$this->gateway()->maybe_capture_payment( $order->get_id() );
-		}
-
-		print "1";
-	}
-
-	/**
-	 * Check charge statuses scheduled action
-	 *
-	 * @param int|null $limit
-	 *
-	 * @return array
-	 */
-	public function check_order_statuses( $limit = '' ): array {
-		if ( empty( $limit ) ) {
-			$limit = $this->gateway()->check_charges_amount;
-		}
-
-		$options = [
-			'limit'          => $limit,
-			'meta_query'     => [
-				[
-					'key'     => WC_Vipps_Recurring_Helper::META_CHARGE_PENDING,
-					'compare' => '=',
-					'value'   => 1
-				]
-			],
-			'payment_method' => $this->gateway()->id
-		];
-
-		if ( $this->gateway()->check_charges_sort_order === 'rand' ) {
-			$options['orderby'] = 'rand';
-		} else {
-			$options['orderby'] = 'post_date';
-			$options['order']   = $this->gateway()->check_charges_sort_order;
-		}
-
-		remove_all_filters( 'posts_orderby' );
-		$orders = wc_get_orders( $options );
-
-		foreach ( $orders as $order ) {
-			$order_id = WC_Vipps_Recurring_Helper::get_id( $order );
-
-			do_action( 'wc_vipps_recurring_before_cron_check_order_status', $order_id );
-			$this->gateway()->check_charge_status( $order_id );
-			do_action( 'wc_vipps_recurring_after_cron_check_order_status', $order_id );
-		}
-
-		return $orders;
-	}
-
-	/**
-	 * Check the status of gateway change requests
-	 */
-	public function check_gateway_change_agreement_statuses() {
-		$subscriptions = wcs_get_subscriptions( [
-			'subscription_status' => [ 'active', 'pending', 'on-hold' ],
-			'meta_query'          => [
-				[
-					'key'     => WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_WAITING_FOR_GATEWAY_CHANGE,
-					'compare' => '=',
-					'value'   => 1
-				]
-			]
-		] );
-
-		foreach ( $subscriptions as $subscription ) {
-			// check charge status
-			$this->gateway()->maybe_process_gateway_change( $subscription->get_id() );
-		}
-	}
-
-	/**
-	 * Update a subscription's details in the app
-	 */
-	public function update_subscription_details_in_app() {
-		$subscriptions = wcs_get_subscriptions( [
-			'subscriptions_per_page' => 5,
-			'subscription_status'    => [ 'active', 'pending-cancel', 'cancelled', 'on-hold' ],
-			'meta_query'             => [
-				[
-					'key'     => WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP,
-					'compare' => '=',
-					'value'   => 1,
-				]
-			]
-		] );
-
-		foreach ( $subscriptions as $subscription ) {
-			// check charge status
-			$this->gateway()->maybe_update_subscription_details_in_app( $subscription->get_id() );
-		}
-	}
-
-	public function check_orders_marked_for_deletion() {
-		$options = [
-			'limit'          => 25,
-			'payment_method' => $this->gateway()->id,
-			'meta_query'     => [
-				[
-					'key'     => WC_Vipps_Recurring_Helper::META_ORDER_MARKED_FOR_DELETION,
-					'compare' => '=',
-					'value'   => 1
-				]
-			]
-		];
-
-		$orders = wc_get_orders( $options );
-
-		WC_Vipps_Recurring_Logger::log( sprintf( "Running check_orders_marked_for_deletion for %s orders", count( $orders ) ) );
-
-		foreach ( $orders as $order ) {
-			// If this order has been manually updated in the mean-time, we no longer want to delete it.
-			// Similarly, if it has a billing email we don't want to delete it.
-			$empty_email = $order->get_billing_email() === WC_Vipps_Recurring_Helper::FAKE_USER_EMAIL || ! $order->get_billing_email();
-
-			WC_Vipps_Recurring_Logger::log( sprintf( "Checking if order %s should be deleted (status: %s, empty email: %s, is renewal: %s).", WC_Vipps_Recurring_Helper::get_id( $order ), $order->get_status(), $empty_email ? 'Yes' : 'No', wcs_order_contains_renewal( $order ) ? 'Yes' : 'No' ) );
-
-			if ( ! in_array( $order->get_status( 'edit' ), [ 'pending', 'cancelled' ] ) || ! $empty_email ) {
-				WC_Vipps_Recurring_Logger::log( sprintf( "Removing %s from the deletion queue as it should no longer be deleted.", WC_Vipps_Recurring_Helper::get_id( $order ) ) );
-
-				WC_Vipps_Recurring_Helper::delete_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_MARKED_FOR_DELETION );
-				$order->save();
-
-				continue;
-			}
-
-			WC_Vipps_Recurring_Logger::log( sprintf( "Deleting %s.", WC_Vipps_Recurring_Helper::get_id( $order ) ) );
-
-			if ( ! wcs_order_contains_renewal( $order ) ) {
-				$subscriptions = wcs_get_subscriptions_for_order( $order );
-				foreach ( $subscriptions as $subscription ) {
-					// Do not delete active subscriptions under any circumstances.
-					if ( $subscription->get_status() === 'active' ) {
-						continue;
-					}
-
-					$subscription->delete();
-				}
-			}
-
-			$order->delete();
-		}
-	}
-
-	/**
-	 * Adds plugin action links.
-	 *
-	 * @since 1.0.0
-	 * @version 4.0.0
-	 */
-	public function plugin_action_links( $links ): array {
-		// IOK 2025-01-13 temporarily deactivated, because there is currently two
-		// sets of settings, and not enough room to disambituate between them (at least in norwegian).
-		return $links;
-
-		$plugin_links = [
-			'<a href="admin.php?page=wc-settings&tab=checkout&section=vipps_recurring">' . esc_html__( 'Settings', 'woo-vipps' ) . '</a>',
-		];
-
-		return array_merge( $plugin_links, $links );
-	}
-
-	/**
-	 * Handles upgrade routines.
-	 *
-	 * @since 3.1.0
-	 * @version 3.1.0
-	 */
-	public function install() {
-		$this->upgrade();
-	}
-
-	/**
-	 * Add the gateways to WooCommerce.
-	 *
-	 * @param $methods
-	 *
-	 * @return array
-	 * @since 1.0.0
-	 * @version 4.0.0
-	 */
-	public function add_gateways( $methods ): array {
-		if ( function_exists( 'wcs_create_renewal_order' ) && class_exists( 'WC_Subscriptions_Order' ) ) {
-			require_once( dirname( __FILE__ ) . "/wc-gateway-vipps-recurring.php" );
-
-			$methods[] = WC_Gateway_Vipps_Recurring::get_instance();
-		}
-
-		return $methods;
-	}
-
-	/**
-	 * Enqueue our CSS and other assets.
-	 */
-	public function wp_enqueue_scripts() {
-		wp_enqueue_style(
-			'woo-vipps-recurring',
-
-			WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/build/main.css', [],
-			filemtime( WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/main.css' )
-		);
-
-		$asset = require WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/main.asset.php';
-
-		wp_enqueue_script(
-			'woo-vipps-recurring',
-			WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/build/main.js',
-			$asset['dependencies'],
-			filemtime( WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/main.js' ),
-			true
-		);
-
-		$continue_shopping_link_page = ! empty( $this->gateway()->continue_shopping_link_page )
-			? $this->gateway()->continue_shopping_link_page
-			: wc_get_page_id( 'shop' );
-
-		$continue_shopping_url = $continue_shopping_link_page ? get_permalink( $continue_shopping_link_page ) : home_url();
-		if ( empty( $continue_shopping_link_page ) ) {
-			$continue_shopping_url = home_url();
-		}
-
-		wp_localize_script( 'woo-vipps-recurring', 'VippsMobilePaySettings', [
-			'logo'                => WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/images/' . $this->gateway()->brand . '-logo.svg',
-			'continueShoppingUrl' => $continue_shopping_url
-		] );
-
-		wp_set_script_translations( 'woo-vipps-recurring', 'woo-vipps', dirname( WC_VIPPS_MAIN_FILE ) . '/languages' );
-	}
-
-	/**
-	 * Enqueue our CSS and other assets.
-	 */
-	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'woo-vipps-recurring', plugins_url( 'assets/css/vipps-recurring-admin.css', WC_VIPPS_RECURRING_MAIN_FILE ), [],
-			filemtime( dirname( WC_VIPPS_RECURRING_MAIN_FILE ) . '/assets/css/vipps-recurring-admin.css' ) );
-
-		$this->ajax_config['nonce']    = wp_create_nonce( 'vipps_recurring_ajax_nonce' );
-		$this->ajax_config['currency'] = get_woocommerce_currency();
-
-		wp_enqueue_script(
-			'woo-vipps-recurring-admin',
-			plugins_url( 'assets/js/vipps-recurring-admin.js', WC_VIPPS_RECURRING_MAIN_FILE ),
-			[ 'wp-i18n' ],
-			filemtime( dirname( WC_VIPPS_RECURRING_MAIN_FILE ) . "/assets/js/vipps-recurring-admin.js" ),
-			true
-		);
-
-		wp_localize_script( 'woo-vipps-recurring-admin', 'VippsRecurringConfig', $this->ajax_config );
-		wp_set_script_translations( 'woo-vipps-recurring-admin', 'woo-vipps', dirname( WC_VIPPS_MAIN_FILE ) . '/languages' );
-	}
-
-	/**
-	 * @param $schedules
-	 *
-	 * @return mixed
-	 */
-	public function woocommerce_vipps_recurring_add_cron_schedules( $schedules ) {
-		$schedules['one_minute'] = [
-			'interval' => 60,
-			'display'  => esc_html__( 'Every One Minute' ),
-		];
-
-		return $schedules;
-	}
-
-	/**
-	 * @throws WC_Vipps_Recurring_Exception
-	 * @throws WC_Vipps_Recurring_Temporary_Exception
-	 * @throws WC_Vipps_Recurring_Config_Exception
-	 */
-	public function handle_webhook_callback() {
-		wc_nocache_headers();
-		status_header( 202, "Accepted" );
-
-		$raw_input = @file_get_contents( 'php://input' );
-		$body      = @json_decode( $raw_input, true );
-
-		// If we have a sessionId, this indicates that we are dealing with a Checkout callback.
-		// Fire a hook and let Checkout deal with its own logic.
-		if ( isset( $body['sessionId'] ) ) {
-			$authorization_token = $_SERVER['HTTP_AUTHORIZATION'];
-
-			do_action( 'wc_vipps_recurring_checkout_callback', $body, $authorization_token );
-
-			// Early return to avoid potential errors downstream.
-			return;
-		}
-
-		$callback = $_REQUEST['callback'] ?? "";
-
-		if ( $callback !== "webhook" ) {
-			return;
-		}
-
-		if ( ! $body ) {
-			$error = json_last_error_msg();
-			WC_Vipps_Recurring_Logger::log( sprintf( "Did not understand callback from Vipps/MobilePay with body: %s – error: %s", empty( $raw_input ) ? "(empty string)" : $raw_input, $error ) );
-
-			return;
-		}
-
-		$local_webhooks = $this->gateway()->webhook_get_local()[ $this->gateway()->merchant_serial_number ];
-		$local_webhook  = array_pop( $local_webhooks );
-		$secret         = $local_webhook ? ( $local_webhook['secret'] ?? false ) : false;
-
-		$order_id = $body['chargeExternalId'] ?? $body['agreementId'] ?? $body['agreementExternalId'];
-		if ( ! $order_id ) {
-			WC_Vipps_Recurring_Logger::log( sprintf( "Could not find order id in webhook with body %s", json_encode( $body ) ) );
-
-			return;
-		}
-
-		if ( ! $secret ) {
-			WC_Vipps_Recurring_Logger::log( sprintf( "Cannot verify webhook callback for order %s - this shop does not know the secret. You should delete all unwanted webhooks. If you are using the same MSN on several shops, this callback is probably for one of the others.", $order_id ) );
-		}
-
-		if ( ! $this->verify_webhook( $raw_input, $secret ) ) {
-			return;
-		}
-
-		do_action( "wc_vipps_recurring_webhook_callback", $body, $raw_input );
-
-		// We now have a validated webhook
-		$this->gateway()->handle_webhook_callback( $body );
-	}
-
-	public function verify_webhook( $serialized, $secret ): bool {
-		$expected_auth = $_SERVER['HTTP_AUTHORIZATION'] ?? ( $_SERVER['HTTP_X_VIPPS_AUTHORIZATION'] ?? "" );
-		$expected_date = $_SERVER['HTTP_X_MS_DATE'] ?? '';
-
-		$hashed_payload = base64_encode( hash( 'sha256', $serialized, true ) );
-		$path_and_query = $_SERVER['REQUEST_URI'];
-		$host           = $_SERVER['HTTP_HOST'];
-		$toSign         = "POST\n{$path_and_query}\n$expected_date;$host;$hashed_payload";
-		$signature      = base64_encode( hash_hmac( 'sha256', $toSign, $secret, true ) );
-		$auth           = "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=$signature";
-
-		return ( $auth == $expected_auth );
-	}
-
-	public function generate_order_prefix(): string {
-		$parts = parse_url( site_url() );
-		if ( ! $parts ) {
-			return 'woo-';
-		}
-
-		$domain = explode( ".", $parts['host'] ?? '' );
-		if ( empty( $domain ) ) {
-			return 'woo-';
-		}
-
-		$first  = strtolower( $domain[0] );
-		$second = $domain[1] ?? '';
-
-		// Select first part of domain unless that has no content, otherwise second. Default to "woo-" again.
-		$key = $first;
-		if ( in_array( $first, [ 'www', 'test', 'dev', 'vdev' ] ) && ! empty( $second ) ) {
-			$key = $second;
-		}
-
-		// Use only 8 chars for the site. Try to make it so by dropping vowels, if that doesn't succeed, just chop it.
-		$key = sanitize_title( $key );
-		$len = strlen( $key );
-		if ( $len <= 8 ) {
-			return "woo-$key-";
-		}
-
-		$kzk = preg_replace( "/[aeiouæøåüö]/i", "", $key );
-		if ( strlen( $kzk ) <= 8 ) {
-			return "woo-$kzk-";
-		}
-
-		return "woo-" . substr( $key, 0, 8 ) . "-";
-	}
+        return apply_filters( 'wc_vipps_recurring_cart_has_subscription_product', $active, WC()->cart->get_cart_contents() );
+    }
+
+    public function maybe_disable_gateway( $methods ) {
+        if ( is_admin() || ! is_checkout() ) {
+            return $methods;
+        }
+
+        $show_gateway = $this->gateway_should_be_active( $methods );
+
+        if ( ! $show_gateway ) {
+            unset( $methods['vipps_recurring'] );
+        }
+
+        return $methods;
+    }
+
+    /**
+     * @return string
+     */
+    public function handle_check_statuses_bulk_action(): string {
+        $sendback = remove_query_arg( [ 'orders' ], wp_get_referer() );
+
+        if ( isset( $_GET['orders'] ) ) {
+            $order_ids = $_GET['orders'];
+
+            foreach ( $order_ids as $order_id ) {
+                // check charge status
+                $this->gateway()->check_charge_status( $order_id, true );
+            }
+
+            $sendback = add_query_arg( 'statuses_checked', 1, $sendback );
+        }
+
+        return $sendback;
+    }
+
+    /**
+     * Setup the screen for our special setting and action tables
+     */
+    public function setup_screen() {
+        global $wc_vipps_recurring_list_table_pending_charges,
+               $wc_vipps_recurring_list_table_failed_charges;
+
+        $screen_id = false;
+
+        if ( function_exists( 'get_current_screen' ) ) {
+            $screen    = get_current_screen();
+            $screen_id = isset( $screen, $screen->id ) ? $screen->id : '';
+        }
+
+        if ( ! empty( $_REQUEST['screen'] ) ) {
+            $screen_id = wc_clean( wp_unslash( $_REQUEST['screen'] ) );
+        }
+
+        if ( $screen_id === 'settings_page_woo-vipps-recurring' ) {
+            include_once 'admin/list-tables/wc-vipps-recurring-list-table-pending-charges.php';
+            include_once 'admin/list-tables/wc-vipps-recurring-list-table-failed-charges.php';
+
+            $wc_vipps_recurring_list_table_pending_charges = new WC_Vipps_Recurring_Admin_List_Pending_Charges( [
+                'screen' => $screen_id . '_pending-charges'
+            ] );
+            $wc_vipps_recurring_list_table_failed_charges  = new WC_Vipps_Recurring_Admin_List_Failed_Charges( [
+                'screen' => $screen_id . '_failed-charges'
+            ] );
+        }
+
+        if ( $wc_vipps_recurring_list_table_pending_charges
+             && $wc_vipps_recurring_list_table_pending_charges->current_action()
+             && $wc_vipps_recurring_list_table_pending_charges->current_action() === 'check_status' ) {
+            $sendback = $this->handle_check_statuses_bulk_action();
+
+            wp_redirect( $sendback );
+        }
+
+        if ( $wc_vipps_recurring_list_table_failed_charges
+             && $wc_vipps_recurring_list_table_failed_charges->current_action()
+             && $wc_vipps_recurring_list_table_failed_charges->current_action() === 'check_status' ) {
+            $sendback = $this->handle_check_statuses_bulk_action();
+
+            wp_redirect( $sendback );
+        }
+
+        // Ensure the table handler is only loaded once. Prevents multiple loads if a plugin calls check_ajax_referer many times.
+        remove_action( 'current_screen', [ $this, 'setup_screen' ] );
+    }
+
+    /**
+     * Make admin menu entry
+     */
+    public function admin_menu() {
+        add_options_page(
+            __( 'Vipps/MobilePay Recurring Payments', 'woo-vipps' ),
+            __( 'Vipps/MobilePay Recurring Payments', 'woo-vipps' ),
+            'manage_options',
+            'woo-vipps-recurring',
+            [ $this, 'admin_menu_page_html' ]
+        );
+    }
+
+    /**
+     * Admin menu page HTML
+     */
+    public function admin_menu_page_html() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        include __DIR__ . '/pages/admin/vipps-recurring-admin-menu-page.php';
+    }
+
+    public function custom_action_endpoints( $rewrites ) {
+        $rewrites->rules = array_merge(
+            [ 'vipps-mobilepay-recurring-payment/?$' => 'index.php?vipps_recurring_action=payment-redirect' ],
+            $rewrites->rules
+        );
+
+        return $rewrites;
+    }
+
+    public function custom_action_query_vars( $query_vars ) {
+        $query_vars[] = 'vipps_recurring_action';
+
+        return $query_vars;
+    }
+
+    public function custom_action_page_template( $original_template ) {
+        $custom_action = get_query_var( 'vipps_recurring_action' );
+
+        if ( ! empty ( $custom_action ) ) {
+            include WC_VIPPS_RECURRING_PLUGIN_PATH . '/includes/pages/payment-redirect-page.php';
+            die;
+        }
+
+        return $original_template;
+    }
+
+    public function maybe_create_checkout_page() {
+        $checkout_page_id    = wc_get_page_id( 'vipps_mobilepay_recurring_checkout' );
+        $should_create_pages = ! $checkout_page_id || ! get_post_status( $checkout_page_id );
+
+        if ( ! $should_create_pages ) {
+            return;
+        }
+
+        // Piggybacks off of WooCommerce's default logic for creating the checkout page.
+        // This is possible because we override the shortcode.
+        delete_option( 'woocommerce_vipps_recurring_checkout_page_id' );
+        WC_Install::create_pages();
+    }
+
+    /**
+     * Vipps Checkout replaces the default checkout page, and currently uses its own page for this which needs to exist
+     */
+    public function woocommerce_create_pages( $data ) {
+        $checkout_enabled = get_option( WC_Vipps_Recurring_Helper::OPTION_CHECKOUT_ENABLED, false );
+        if ( ! $checkout_enabled ) {
+            return $data;
+        }
+
+        $data['vipps_recurring_checkout'] = array(
+            'name'    => _x( 'vipps_recurring_checkout', 'Page slug', 'woo-vipps' ),
+            'title'   => _x( 'Vipps MobilePay Recurring Checkout', 'Page title', 'woo-vipps' ),
+            'content' => '<!-- wp:shortcode -->[' . 'vipps_recurring_checkout' . ']<!-- /wp:shortcode -->',
+        );
+
+        return $data;
+    }
+
+    /**
+     * Force check status of all pending charges
+     */
+    public function wp_ajax_vipps_recurring_force_check_charge_statuses(): void {
+        try {
+            /* translators: amount of orders checked */
+            echo sprintf( __( 'Done. Checked the status of %s orders', 'woo-vipps' ), count( $this->check_order_statuses( - 1 ) ) );
+        } catch ( Exception $e ) {
+            echo __( 'Failed to finish checking the status of all orders. Please try again.', 'woo-vipps' );
+        }
+
+        wp_die();
+    }
+
+    /**
+     * @param $tabs
+     *
+     * @return mixed
+     */
+    public function woocommerce_product_data_tabs( $tabs ) {
+        $tabs['wc_vipps_recurring'] = [
+            'label'    => __( 'Vipps/MobilePay Recurring Payments', 'woo-vipps' ),
+            'target'   => 'wc_vipps_recurring_product_data',
+            'priority' => 100,
+        ];
+
+        return $tabs;
+    }
+
+    /**
+     * Tab content
+     */
+    public function woocommerce_product_data_panels(): void {
+        echo '<div id="wc_vipps_recurring_product_data" class="panel woocommerce_options_panel hidden">';
+
+        woocommerce_wp_checkbox( [
+            'id'          => WC_Vipps_Recurring_Helper::META_PRODUCT_DIRECT_CAPTURE,
+            'value'       => get_post_meta( get_the_ID(), WC_Vipps_Recurring_Helper::META_PRODUCT_DIRECT_CAPTURE, true ),
+            'label'       => __( 'Capture payment instantly', 'woo-vipps' ),
+            'description' => __( 'Capture payment instantly even if the product is not virtual. Please make sure you are following the local jurisdiction in your country when using this option.', 'woo-vipps' ),
+            'desc_tip'    => true,
+        ] );
+
+        woocommerce_wp_select( [
+            'id'          => WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_SOURCE,
+            'value'       => get_post_meta( get_the_ID(), WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_SOURCE, true ) ?: 'title',
+            'label'       => __( 'Description source', 'woo-vipps' ),
+            'description' => __( 'Where we should source the agreement description from. Displayed in the Vipps/MobilePay app.', 'woo-vipps' ),
+            'desc_tip'    => true,
+            'options'     => [
+                'none'              => __( 'None', 'woo-vipps' ),
+                'short_description' => __( 'Product short description', 'woo-vipps' ),
+                'custom'            => __( 'Custom', 'woo-vipps' )
+            ]
+        ] );
+
+        woocommerce_wp_text_input( [
+            'id'          => WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_TEXT,
+            'value'       => get_post_meta( get_the_ID(), WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_TEXT, true ),
+            'label'       => __( 'Custom description', 'woo-vipps' ),
+            'description' => __( 'If the description source is set to "custom" this text will be used.', 'woo-vipps' ),
+            'placeholder' => __( 'Max 100 characters', 'woo-vipps' ),
+            'desc_tip'    => true,
+        ] );
+
+        echo '</div>';
+    }
+
+    /**
+     * Save our custom fields
+     *
+     * @param $post_id
+     */
+    public function woocommerce_process_product_meta( $post_id ) {
+        $capture_instantly = isset( $_POST[ WC_Vipps_Recurring_Helper::META_PRODUCT_DIRECT_CAPTURE ] ) ? 'yes' : 'no';
+        update_post_meta( $post_id, WC_Vipps_Recurring_Helper::META_PRODUCT_DIRECT_CAPTURE, $capture_instantly );
+
+        update_post_meta( $post_id, WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_SOURCE, $_POST[ WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_SOURCE ] );
+        update_post_meta( $post_id, WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_TEXT, $_POST[ WC_Vipps_Recurring_Helper::META_PRODUCT_DESCRIPTION_TEXT ] ?? '' );
+    }
+
+    /**
+     * @param $order
+     */
+    public function order_item_add_action_buttons( $order ): void {
+        $this->order_item_add_capture_button( $order );
+    }
+
+    /**
+     * @param $order
+     */
+    public function order_item_add_capture_button( $order ): void {
+        if ( $order->get_type() !== 'shop_order' ) {
+            return;
+        }
+
+        $payment_method = WC_Vipps_Recurring_Helper::get_payment_method( $order );
+        if ( $payment_method !== $this->gateway()->id ) {
+            // If this is not the payment method, an agreement would not be available.
+            return;
+        }
+
+        $show_capture_button = WC_Vipps_Recurring_Helper::can_capture_charge_for_order( $order );
+
+        if ( ! apply_filters( 'wc_vipps_recurring_show_capture_button', $show_capture_button, $order ) ) {
+            return;
+        }
+
+        $is_captured = WC_Vipps_Recurring_Helper::is_charge_captured_for_order( $order );
+
+        if ( $show_capture_button && ! $is_captured ) {
+            $logo = plugins_url( 'assets/images/' . $this->gateway()->brand . '-logo-white.svg', WC_VIPPS_RECURRING_MAIN_FILE );
+
+            print '<button type="button" data-order-id="' . $order->get_id() . '" data-action="capture_payment" class="button generate-items capture-payment-button ' . $this->gateway()->brand . '"><img border="0" style="display:inline;height:2ex;vertical-align:text-bottom" class="inline" alt="0" src="' . $logo . '"/> ' . __( 'Capture payment', 'woo-vipps' ) . '</button>';
+        }
+    }
+
+    public function order_handle_vipps_recurring_action() {
+        check_ajax_referer( 'vipps_recurring_ajax_nonce', 'nonce' );
+
+        $order = wc_get_order( intval( $_REQUEST['orderId'] ) );
+        if ( ! is_a( $order, 'WC_Order' ) ) {
+            return;
+        }
+
+        if ( $order->get_payment_method() != $this->gateway()->id ) {
+            return;
+        }
+
+        $action = isset( $_REQUEST['do'] ) ? sanitize_title( $_REQUEST['do'] ) : 'none';
+
+        if ( $action == 'capture_payment' ) {
+            $this->gateway()->maybe_capture_payment( $order->get_id() );
+        }
+
+        print "1";
+    }
+
+    /**
+     * Check charge statuses scheduled action
+     *
+     * @param int|null $limit
+     *
+     * @return array
+     */
+    public function check_order_statuses( $limit = '' ): array {
+        if ( empty( $limit ) ) {
+            $limit = $this->gateway()->check_charges_amount;
+        }
+
+        $options = [
+            'limit'          => $limit,
+            'meta_query'     => [
+                [
+                    'key'     => WC_Vipps_Recurring_Helper::META_CHARGE_PENDING,
+                    'compare' => '=',
+                    'value'   => 1
+                ]
+            ],
+            'payment_method' => $this->gateway()->id
+        ];
+
+        if ( $this->gateway()->check_charges_sort_order === 'rand' ) {
+            $options['orderby'] = 'rand';
+        } else {
+            $options['orderby'] = 'post_date';
+            $options['order']   = $this->gateway()->check_charges_sort_order;
+        }
+
+        remove_all_filters( 'posts_orderby' );
+        $orders = wc_get_orders( $options );
+
+        foreach ( $orders as $order ) {
+            $order_id = WC_Vipps_Recurring_Helper::get_id( $order );
+
+            do_action( 'wc_vipps_recurring_before_cron_check_order_status', $order_id );
+            $this->gateway()->check_charge_status( $order_id );
+            do_action( 'wc_vipps_recurring_after_cron_check_order_status', $order_id );
+        }
+
+        return $orders;
+    }
+
+    /**
+     * Check the status of gateway change requests
+     */
+    public function check_gateway_change_agreement_statuses() {
+        $subscriptions = wcs_get_subscriptions( [
+            'subscription_status' => [ 'active', 'pending', 'on-hold' ],
+            'meta_query'          => [
+                [
+                    'key'     => WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_WAITING_FOR_GATEWAY_CHANGE,
+                    'compare' => '=',
+                    'value'   => 1
+                ]
+            ]
+        ] );
+
+        foreach ( $subscriptions as $subscription ) {
+            // check charge status
+            $this->gateway()->maybe_process_gateway_change( $subscription->get_id() );
+        }
+    }
+
+    /**
+     * Update a subscription's details in the app
+     */
+    public function update_subscription_details_in_app() {
+        $subscriptions = wcs_get_subscriptions( [
+            'subscriptions_per_page' => 5,
+            'subscription_status'    => [ 'active', 'pending-cancel', 'cancelled', 'on-hold' ],
+            'meta_query'             => [
+                [
+                    'key'     => WC_Vipps_Recurring_Helper::META_SUBSCRIPTION_UPDATE_IN_APP,
+                    'compare' => '=',
+                    'value'   => 1,
+                ]
+            ]
+        ] );
+
+        foreach ( $subscriptions as $subscription ) {
+            // check charge status
+            $this->gateway()->maybe_update_subscription_details_in_app( $subscription->get_id() );
+        }
+    }
+
+    public function check_orders_marked_for_deletion() {
+        $options = [
+            'limit'          => 25,
+            'payment_method' => $this->gateway()->id,
+            'meta_query'     => [
+                [
+                    'key'     => WC_Vipps_Recurring_Helper::META_ORDER_MARKED_FOR_DELETION,
+                    'compare' => '=',
+                    'value'   => 1
+                ]
+            ]
+        ];
+
+        $orders = wc_get_orders( $options );
+
+        WC_Vipps_Recurring_Logger::log( sprintf( "Running check_orders_marked_for_deletion for %s orders", count( $orders ) ) );
+
+        foreach ( $orders as $order ) {
+            // If this order has been manually updated in the mean-time, we no longer want to delete it.
+            // Similarly, if it has a billing email we don't want to delete it.
+            $empty_email = $order->get_billing_email() === WC_Vipps_Recurring_Helper::FAKE_USER_EMAIL || ! $order->get_billing_email();
+
+            WC_Vipps_Recurring_Logger::log( sprintf( "Checking if order %s should be deleted (status: %s, empty email: %s, is renewal: %s).", WC_Vipps_Recurring_Helper::get_id( $order ), $order->get_status(), $empty_email ? 'Yes' : 'No', wcs_order_contains_renewal( $order ) ? 'Yes' : 'No' ) );
+
+            if ( ! in_array( $order->get_status( 'edit' ), [ 'pending', 'cancelled' ] ) || ! $empty_email ) {
+                WC_Vipps_Recurring_Logger::log( sprintf( "Removing %s from the deletion queue as it should no longer be deleted.", WC_Vipps_Recurring_Helper::get_id( $order ) ) );
+
+                WC_Vipps_Recurring_Helper::delete_meta_data( $order, WC_Vipps_Recurring_Helper::META_ORDER_MARKED_FOR_DELETION );
+                $order->save();
+
+                continue;
+            }
+
+            WC_Vipps_Recurring_Logger::log( sprintf( "Deleting %s.", WC_Vipps_Recurring_Helper::get_id( $order ) ) );
+
+            if ( ! wcs_order_contains_renewal( $order ) ) {
+                $subscriptions = wcs_get_subscriptions_for_order( $order );
+                foreach ( $subscriptions as $subscription ) {
+                    // Do not delete active subscriptions under any circumstances.
+                    if ( $subscription->get_status() === 'active' ) {
+                        continue;
+                    }
+
+                    $subscription->delete();
+                }
+            }
+
+            $order->delete();
+        }
+    }
+
+    /**
+     * Adds plugin action links.
+     *
+     * @since 1.0.0
+     * @version 4.0.0
+     */
+    public function plugin_action_links( $links ): array {
+        // IOK 2025-01-13 temporarily deactivated, because there is currently two
+        // sets of settings, and not enough room to disambituate between them (at least in norwegian).
+        return $links;
+
+        $plugin_links = [
+            '<a href="admin.php?page=wc-settings&tab=checkout&section=vipps_recurring">' . esc_html__( 'Settings', 'woo-vipps' ) . '</a>',
+        ];
+
+        return array_merge( $plugin_links, $links );
+    }
+
+    /**
+     * Handles upgrade routines.
+     *
+     * @since 3.1.0
+     * @version 3.1.0
+     */
+    public function install() {
+        $this->upgrade();
+    }
+
+    /**
+     * Add the gateways to WooCommerce.
+     *
+     * @param $methods
+     *
+     * @return array
+     * @since 1.0.0
+     * @version 4.0.0
+     */
+    public function add_gateways( $methods ): array {
+        if ( function_exists( 'wcs_create_renewal_order' ) && class_exists( 'WC_Subscriptions_Order' ) ) {
+            require_once( dirname( __FILE__ ) . "/wc-gateway-vipps-recurring.php" );
+
+            $methods[] = WC_Gateway_Vipps_Recurring::get_instance();
+        }
+
+        return $methods;
+    }
+
+    /**
+     * Enqueue our CSS and other assets.
+     */
+    public function wp_enqueue_scripts() {
+        wp_enqueue_style(
+            'woo-vipps-recurring',
+
+            WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/build/main.css', [],
+            filemtime( WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/main.css' )
+        );
+
+        $asset = require WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/main.asset.php';
+
+        wp_enqueue_script(
+            'woo-vipps-recurring',
+            WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/build/main.js',
+            $asset['dependencies'],
+            filemtime( WC_VIPPS_RECURRING_PLUGIN_PATH . '/assets/build/main.js' ),
+            true
+        );
+
+        $continue_shopping_link_page = ! empty( $this->gateway()->continue_shopping_link_page )
+            ? $this->gateway()->continue_shopping_link_page
+            : wc_get_page_id( 'shop' );
+
+        $continue_shopping_url = $continue_shopping_link_page ? get_permalink( $continue_shopping_link_page ) : home_url();
+        if ( empty( $continue_shopping_link_page ) ) {
+            $continue_shopping_url = home_url();
+        }
+
+        wp_localize_script( 'woo-vipps-recurring', 'VippsMobilePaySettings', [
+            'logo'                => WC_VIPPS_RECURRING_PLUGIN_URL . '/assets/images/' . $this->gateway()->brand . '-logo.svg',
+            'continueShoppingUrl' => $continue_shopping_url
+        ] );
+
+        wp_set_script_translations( 'woo-vipps-recurring', 'woo-vipps', dirname( WC_VIPPS_MAIN_FILE ) . '/languages' );
+    }
+
+    /**
+     * Enqueue our CSS and other assets.
+     */
+    public function admin_enqueue_scripts() {
+        wp_enqueue_style( 'woo-vipps-recurring', plugins_url( 'assets/css/vipps-recurring-admin.css', WC_VIPPS_RECURRING_MAIN_FILE ), [],
+            filemtime( dirname( WC_VIPPS_RECURRING_MAIN_FILE ) . '/assets/css/vipps-recurring-admin.css' ) );
+
+        $this->ajax_config['nonce']    = wp_create_nonce( 'vipps_recurring_ajax_nonce' );
+        $this->ajax_config['currency'] = get_woocommerce_currency();
+
+        wp_enqueue_script(
+            'woo-vipps-recurring-admin',
+            plugins_url( 'assets/js/vipps-recurring-admin.js', WC_VIPPS_RECURRING_MAIN_FILE ),
+            [ 'wp-i18n' ],
+            filemtime( dirname( WC_VIPPS_RECURRING_MAIN_FILE ) . "/assets/js/vipps-recurring-admin.js" ),
+            true
+        );
+
+        wp_localize_script( 'woo-vipps-recurring-admin', 'VippsRecurringConfig', $this->ajax_config );
+        wp_set_script_translations( 'woo-vipps-recurring-admin', 'woo-vipps', dirname( WC_VIPPS_MAIN_FILE ) . '/languages' );
+    }
+
+    /**
+     * @param $schedules
+     *
+     * @return mixed
+     */
+    public function woocommerce_vipps_recurring_add_cron_schedules( $schedules ) {
+        $schedules['one_minute'] = [
+            'interval' => 60,
+            'display'  => esc_html__( 'Every One Minute' ),
+        ];
+
+        return $schedules;
+    }
+
+    /**
+     * @throws WC_Vipps_Recurring_Exception
+     * @throws WC_Vipps_Recurring_Temporary_Exception
+     * @throws WC_Vipps_Recurring_Config_Exception
+     */
+    public function handle_webhook_callback() {
+        wc_nocache_headers();
+        status_header( 202, "Accepted" );
+
+        $raw_input = @file_get_contents( 'php://input' );
+        $body      = @json_decode( $raw_input, true );
+
+        // If we have a sessionId, this indicates that we are dealing with a Checkout callback.
+        // Fire a hook and let Checkout deal with its own logic.
+        if ( isset( $body['sessionId'] ) ) {
+            $authorization_token = $_SERVER['HTTP_AUTHORIZATION'];
+
+            do_action( 'wc_vipps_recurring_checkout_callback', $body, $authorization_token );
+
+            // Early return to avoid potential errors downstream.
+            return;
+        }
+
+        $callback = $_REQUEST['callback'] ?? "";
+
+        if ( $callback !== "webhook" ) {
+            return;
+        }
+
+        if ( ! $body ) {
+            $error = json_last_error_msg();
+            WC_Vipps_Recurring_Logger::log( sprintf( "Did not understand callback from Vipps/MobilePay with body: %s – error: %s", empty( $raw_input ) ? "(empty string)" : $raw_input, $error ) );
+
+            return;
+        }
+
+        $local_webhooks = $this->gateway()->webhook_get_local()[ $this->gateway()->merchant_serial_number ];
+        $local_webhook  = array_pop( $local_webhooks );
+        $secret         = $local_webhook ? ( $local_webhook['secret'] ?? false ) : false;
+
+        $order_id = $body['chargeExternalId'] ?? $body['agreementId'] ?? $body['agreementExternalId'];
+        if ( ! $order_id ) {
+            WC_Vipps_Recurring_Logger::log( sprintf( "Could not find order id in webhook with body %s", json_encode( $body ) ) );
+
+            return;
+        }
+
+        if ( ! $secret ) {
+            WC_Vipps_Recurring_Logger::log( sprintf( "Cannot verify webhook callback for order %s - this shop does not know the secret. You should delete all unwanted webhooks. If you are using the same MSN on several shops, this callback is probably for one of the others.", $order_id ) );
+        }
+
+        if ( ! $this->verify_webhook( $raw_input, $secret ) ) {
+            return;
+        }
+
+        do_action( "wc_vipps_recurring_webhook_callback", $body, $raw_input );
+
+        // We now have a validated webhook
+        $this->gateway()->handle_webhook_callback( $body );
+    }
+
+    public function verify_webhook( $serialized, $secret ): bool {
+        $expected_auth = $_SERVER['HTTP_AUTHORIZATION'] ?? ( $_SERVER['HTTP_X_VIPPS_AUTHORIZATION'] ?? "" );
+        $expected_date = $_SERVER['HTTP_X_MS_DATE'] ?? '';
+
+        $hashed_payload = base64_encode( hash( 'sha256', $serialized, true ) );
+        $path_and_query = $_SERVER['REQUEST_URI'];
+        $host           = $_SERVER['HTTP_HOST'];
+        $toSign         = "POST\n{$path_and_query}\n$expected_date;$host;$hashed_payload";
+        $signature      = base64_encode( hash_hmac( 'sha256', $toSign, $secret, true ) );
+        $auth           = "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=$signature";
+
+        return ( $auth == $expected_auth );
+    }
+
+    public function generate_order_prefix(): string {
+        $parts = parse_url( site_url() );
+        if ( ! $parts ) {
+            return 'woo-';
+        }
+
+        $domain = explode( ".", $parts['host'] ?? '' );
+        if ( empty( $domain ) ) {
+            return 'woo-';
+        }
+
+        $first  = strtolower( $domain[0] );
+        $second = $domain[1] ?? '';
+
+        // Select first part of domain unless that has no content, otherwise second. Default to "woo-" again.
+        $key = $first;
+        if ( in_array( $first, [ 'www', 'test', 'dev', 'vdev' ] ) && ! empty( $second ) ) {
+            $key = $second;
+        }
+
+        // Use only 8 chars for the site. Try to make it so by dropping vowels, if that doesn't succeed, just chop it.
+        $key = sanitize_title( $key );
+        $len = strlen( $key );
+        if ( $len <= 8 ) {
+            return "woo-$key-";
+        }
+
+        $kzk = preg_replace( "/[aeiouæøåüö]/i", "", $key );
+        if ( strlen( $kzk ) <= 8 ) {
+            return "woo-$kzk-";
+        }
+
+        return "woo-" . substr( $key, 0, 8 ) . "-";
+    }
 }

--- a/recurring/includes/wc-vipps-recurring.php
+++ b/recurring/includes/wc-vipps-recurring.php
@@ -382,7 +382,10 @@ class WC_Vipps_Recurring {
 		// The only two reasons to not show our gateway is if the cart supports being purchased by the standard Vipps MobilePay gateway
 		// Or if the cart does not contain a subscription product
 		$active = ! isset( $methods['vipps'] )
-		          && ( WC_Subscriptions_Cart::cart_contains_subscription() || wcs_cart_contains_switches() || isset( $_GET['change_payment_method'] ) );
+		          && ( WC_Subscriptions_Cart::cart_contains_subscription()
+                       || wcs_cart_contains_switches()
+                       || wcs_cart_contains_failed_renewal_order_payment()
+                       || isset( $_GET['change_payment_method'] ) );
 
 		return apply_filters( 'wc_vipps_recurring_cart_has_subscription_product', $active, WC()->cart->get_cart_contents() );
 	}

--- a/recurring/recurring.php
+++ b/recurring/recurring.php
@@ -3,7 +3,7 @@ defined( 'ABSPATH' ) || exit;
 
 // phpcs:disable WordPress.Files.FileName
 
-define( 'WC_VIPPS_RECURRING_VERSION', '2.1.2' );
+define( 'WC_VIPPS_RECURRING_VERSION', '2.1.4' );
 
 /**
  * Polyfills


### PR DESCRIPTION
Apologies for the tabs to spaces change, it makes the PR completely unreadable – the WordPress code style defaults in PhpStorm is to use tabs, but I noticed you use spaces in the rest of the project.

The changelog is as follows:
* Fixed: Actually fixed abandoned Checkout orders not being deleted this time.
* Fixed: Payments towards a failed renewal order are now possible.
* Fixed: When using Checkout it will no longer tell you that you already have a subscription when you haven't paid yet.