### PR TITLE
Fix permission_callback

### DIFF
--- a/payment/Vipps.class.php
+++ b/payment/Vipps.class.php
@@ -229,7 +229,7 @@ class Vipps {
                    register_rest_route('woo-vipps/v1', '/express-products', [
                         'methods' => 'GET',
                         'callback' => [$this, 'rest_express_checkout_products'],
-                        'permissions_callback' => '__return_true',
+                        'permission_callback' => '__return_true',
                    ]);
         });
 


### PR DESCRIPTION
They key used for the permission callback should be permission_callback and not permissions_callback to suppress the _doing_it_wrong() warning