### PR TITLE
Migrate admonition titles to bracket syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Your customers can pay with Vipps, MobilePay, VISA or MasterCard, and they can a
 
 ### Account and pricing
 
-:::warning Checkout – important update
+:::warning[Checkout – important update]
 
 Vipps MobilePay has entered into an agreement to sell the Checkout solution to [Kustom](https://www.kustom.co/).
 


### PR DESCRIPTION
## Summary

Migrate admonition titles from the old `:::type Title` syntax to the preferred `:::type[Title]` bracket syntax, ahead of the Docusaurus v4 migration.

## Test plan

- [ ] Verify admonitions render correctly with titled headings
