### PR TITLE
Fix grammar in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ If you want to contribute: Great! No issue or pull request is too small!
 
 ## Contributing
 
-Contributing is easy. The steps below is intended to be helpful. Please help us improve it.
+Contributing is easy. The steps below are intended to be helpful. Please help us improve it.
 
 1. Create a personal fork of the project [on GitHub](https://github.com/vippsas/vipps-woocommerce).
 1. Clone the fork on your local machine

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you have questions, you can check our [FAQ](https://vippsmobilepay.com/vippsm
 
 If you use [Posten Bring Checkout plugin for WooCommerce](https://wordpress.org/plugins/posten-bring-checkout/) together with Vipps MobilePay Checkout, you will get a streamlined shipping process tightly integrated with the market leading Vipps MobilePay Checkout. Both plugins are free to use, and easy to install.
 
-You can offer your customers a variety of delivery methods, track shipments, print shipping labels, and calculate shipping costs automatically at checkout. Both plugins are designed for simple installation and management through the WooCommerce dashboard and supports both smaller and larger shops looking to streamline their payments with Vipps MobilePay and logistics with Bring.
+You can offer your customers a variety of delivery methods, track shipments, print shipping labels, and calculate shipping costs automatically at checkout. Both plugins are designed for simple installation and management through the WooCommerce dashboard and support both smaller and larger shops looking to streamline their payments with Vipps MobilePay and logistics with Bring.
 
 👉 [Read more on Bring’s website](https://www.bring.no/radgivning/integrasjon/plugin-woocommerce)
 
@@ -100,7 +100,7 @@ They then confirm the payment in the Vipps or MobilePay app.
    The plugin can also be installed manually by uploading the plugin files to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the *Plugins* screen on WordPress.
 3. Go to the *WooCommerce Settings* page, choose *Payments*, and enable Vipps MobilePay.
-4. Go the *Settings* page for the Vipps MobilePay plugin and enter your Vipps MobilePay account keys. Your account keys are available in the [business portal](https://portal.vippsmobilepay.com/). For information, see [How to get account keys](#how-to-get-account-keys-from-the-business-portal).
+4. Go to the *Settings* page for the Vipps MobilePay plugin and enter your Vipps MobilePay account keys. Your account keys are available in the [business portal](https://portal.vippsmobilepay.com/). For information, see [How to get account keys](#how-to-get-account-keys-from-the-business-portal).
 
 ## How to get account keys from the business portal
 

--- a/recurring/README.md
+++ b/recurring/README.md
@@ -115,7 +115,7 @@ The [WooCommerce Subscriptions Importer and Exporter plugin](https://github.com/
 
 After installing the plugin you need to first and foremost familiarize yourself with the [Importer Usage Guide](https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter?tab=readme-ov-file#importer-usage-guide).
 
-While creating your CSV file, you need to make sure that you are mapping the fields as specified in the [column docs](https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter?tab=readme-ov-file#column-mapping). For Vipps MobilePay specifically, you need to set the following fields for subscriptions to work properly:
+While creating your CSV file, make sure that you are mapping the fields as specified in the [column docs](https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter?tab=readme-ov-file#column-mapping). For Vipps MobilePay specifically, you need to set the following fields for subscriptions to work properly:
 
 1. The `payment_method` field needs to be set to `vipps_recurring`.
 2. The `_agreement_id` field needs to be set to the agreement ID from Vipps MobilePay.

--- a/recurring/README.md
+++ b/recurring/README.md
@@ -115,7 +115,7 @@ The [WooCommerce Subscriptions Importer and Exporter plugin](https://github.com/
 
 After installing the plugin you need to first and foremost familiarize yourself with the [Importer Usage Guide](https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter?tab=readme-ov-file#importer-usage-guide).
 
-While creating your CSV file, you need to make sure that you are mapping the fields as specific in the [column docs](https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter?tab=readme-ov-file#column-mapping). For Vipps MobilePay specifically, you need to set the following fields for subscriptions to work properly:
+While creating your CSV file, you need to make sure that you are mapping the fields as specified in the [column docs](https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter?tab=readme-ov-file#column-mapping). For Vipps MobilePay specifically, you need to set the following fields for subscriptions to work properly:
 
 1. The `payment_method` field needs to be set to `vipps_recurring`.
 2. The `_agreement_id` field needs to be set to the agreement ID from Vipps MobilePay.


### PR DESCRIPTION
Conservative grammar fixes across CONTRIBUTING.md, README.md, and recurring/README.md: subject-verb agreement, missing prepositions, and wrong adjective form ('specific' to 'specified'). No functional content changed.